### PR TITLE
docs: translate project text and prompts to Chinese

### DIFF
--- a/.claude/skills/dev-local-setup/SKILL.md
+++ b/.claude/skills/dev-local-setup/SKILL.md
@@ -1,94 +1,90 @@
 ---
 name: dev-local-setup
 description: >
-  Scaffold a one-command `dev-local` launcher for ANY codebase. Investigates the
-  repo to find its services, ports, and infra dependencies, then generates a
-  single `scripts/dev-local.sh` (up/down/status/logs/restart) that runs every
-  dev server in one tmux session, plus a short skill doc describing it. Use when
-  someone says "set up dev-local", "make a one-command dev launcher", "I want
-  one script to start this repo", "scaffold dev-local for this project".
+  为任意代码库脚手架生成一条命令的 `dev-local` 启动器。调研
+  仓库找出它的服务、端口和基础设施依赖，然后生成单个
+  `scripts/dev-local.sh`（up/down/status/logs/restart），在一个 tmux 会话里跑起每个
+  dev 服务器，外加一份简短的 skill 文档描述它。当有人说"设置
+  dev-local"、"做一个一条命令的 dev 启动器"、"我想要一个脚本启动这个仓库"、
+  "为本项目脚手架生成 dev-local"时使用。
 user_invocable: true
 ---
 
-# Set up a `dev-local` launcher for this codebase
+# 为本代码库装配 `dev-local` 启动器
 
-Goal: produce **one script** (`scripts/dev-local.sh`) that a person or agent runs
-to bring the whole local stack up — every long-lived dev server in its own tmux
-window, plus any infra (DB, cache, queues) the app needs — and a short skill doc
-so it's discoverable later.
+目标：产出**一个脚本**（`scripts/dev-local.sh`），人或 agent 运行它就能把整个
+本地栈拉起来 —— 每个长期运行的 dev 服务器在自己的 tmux 窗口里，外加应用
+需要的任何基础设施（DB、缓存、队列）—— 以及一份简短的 skill 文档，方便日后发现。
 
-Do NOT start any dev servers yourself. You are *generating* the launcher, not
-running it. Build it, syntax-check it, then hand it to the user to run.
+不要自己启动任何 dev 服务器。你是在*生成*启动器，不是
+运行它。构建它、做语法检查，然后交给用户运行。
 
-## Step 1 — Investigate the repo (don't guess)
+## 第 1 步 —— 调研仓库（不要猜）
 
-Discover the real facts before writing anything:
+在写任何东西之前先发现真实事实：
 
-1. **Package manager & layout** — look for `pnpm-workspace.yaml` / `turbo.json` /
-   `nx.json` / `lerna.json` (monorepo) or a single `package.json`, `Cargo.toml`,
-   `go.mod`, `pyproject.toml`, `Makefile`, `Procfile`, `docker-compose.yml`.
-2. **Services to run** — each app/package with a `dev`/`start`/`serve` script, or
-   each `Procfile` line, or each `docker-compose` service. Note the exact command
-   to start each (e.g. `pnpm --filter <name> run dev`, `npm run dev`, `cargo run`,
-   `uvicorn app:app --reload`).
-3. **Ports** — grep configs and `.env` for the port each service binds
-   (`PORT`, `listen(`, `server.port`, framework config like `rsbuild.config`,
-   `vite.config`, `next.config`). Record which talks to which.
-4. **Infra dependencies** — does a backend need Postgres / Supabase / MySQL /
-   Redis / Mongo / Kafka? Check `.env`(`.local`), ORM config, `docker-compose`,
-   and connection-string defaults. Decide how to provide each locally
-   (`supabase start`, a Docker container, an existing `docker-compose`).
-5. **First-run setup** — migrations, seed, codegen, `install`. Note the commands
-   but keep them OUT of the default `up` path (offer a separate subcommand).
-6. **Env files** — confirm a committed `.env.example`/`.env`; never invent or
-   print secrets. The script must not inject credentials.
+1. **包管理器与布局** —— 找 `pnpm-workspace.yaml` / `turbo.json` /
+   `nx.json` / `lerna.json`（monorepo）或单个 `package.json`、`Cargo.toml`、
+   `go.mod`、`pyproject.toml`、`Makefile`、`Procfile`、`docker-compose.yml`。
+2. **要运行的服务** —— 每个带 `dev`/`start`/`serve` 脚本的 app/package，或
+   每个 `Procfile` 行，或每个 `docker-compose` 服务。记下启动每个的精确命令
+   （例如 `pnpm --filter <name> run dev`、`npm run dev`、`cargo run`、
+   `uvicorn app:app --reload`）。
+3. **端口** —— grep 配置和 `.env` 找每个服务绑定的端口
+   （`PORT`、`listen(`、`server.port`、框架配置如 `rsbuild.config`、
+   `vite.config`、`next.config`）。记录谁连谁。
+4. **基础设施依赖** —— 后端是否需要 Postgres / Supabase / MySQL /
+   Redis / Mongo / Kafka？查 `.env`（`.local`）、ORM 配置、`docker-compose`、
+   以及连接字符串默认值。决定本地如何提供每一个
+   （`supabase start`、一个 Docker 容器、一个已有的 `docker-compose`）。
+5. **首次运行设置** —— migration、seed、codegen、`install`。记下命令
+   但让它们留在默认 `up` 路径之外（提供一个单独子命令）。
+6. **Env 文件** —— 确认有已提交的 `.env.example`/`.env`；绝不发明或
+   打印密钥。脚本绝不能注入凭据。
 
-Write down a small table: service → command → port → depends-on. That table is
-the spec for the script.
+写下一张小表：服务 → 命令 → 端口 → 依赖。这张表就是
+脚本的规格。
 
-## Step 2 — Generate `scripts/dev-local.sh`
+## 第 2 步 —— 生成 `scripts/dev-local.sh`
 
-Adapt the skeleton in `assets/dev-local.template.sh` (same directory as this
-skill). Fill in the discovered services, ports, and infra. Keep these
-invariants:
+改编 `assets/dev-local.template.sh`（与本 skill 同目录）里的骨架。填入发现的
+服务、端口和基础设施。保持这些不变量：
 
-- **One tmux session**, one window per long-lived server. Idempotent: re-running
-  `up` leaves existing windows alone instead of duplicating them.
-- **Preflight** that fails fast with install hints when a required tool is
-  missing (tmux, the package manager, Docker if infra needs it).
-- **Infra brought up before servers**, reused if already running.
-- Subcommands: `up`, `down` (and `down --all` to stop infra), `status` (window
-  list + port check), `logs <name>`, `restart <name>`, `attach`, plus any
-  project-specific one-shots (`migrate`, `seed`).
-- Resolve repo root from the script's own location so it works from any cwd.
-- No secrets in the script. Print URLs and a port check at the end of `up`.
+- **一个 tmux 会话**，每个长期运行的服务器一个窗口。幂等：重跑
+  `up` 时不动已有窗口，而不是重复创建。
+- **Preflight**，缺工具时带安装提示快速失败
+  （tmux、包管理器、基础设施需要时的 Docker）。
+- **基础设施先于服务器拉起**，已在跑则复用。
+- 子命令：`up`、`down`（以及 `down --all` 停基础设施）、`status`（窗口
+  列表 + 端口检查）、`logs <name>`、`restart <name>`、`attach`，外加任何
+  项目特定的一次性命令（`migrate`、`seed`）。
+- 从脚本自身位置解析仓库根，这样从任意 cwd 都能工作。
+- 脚本里不放密钥。`up` 结束时打印 URL 和端口检查。
 
-If the repo has **no infra needs**, drop the Docker/DB parts entirely — keep it
-to preflight + tmux windows. Match the script's complexity to the repo; simpler
-is better.
+如果仓库**没有基础设施需求**，整个删掉 Docker/DB 部分 —— 只保留
+preflight + tmux 窗口。让脚本的复杂度匹配仓库；越简单越好。
 
-Then: `chmod +x scripts/dev-local.sh` and `bash -n scripts/dev-local.sh` to
-syntax-check. Verify the read-only `status` path runs cleanly. Do not run `up`.
+然后：`chmod +x scripts/dev-local.sh` 并 `bash -n scripts/dev-local.sh` 做
+语法检查。验证只读的 `status` 路径能干净运行。不要跑 `up`。
 
-## Step 3 — Write a short skill doc
+## 第 3 步 —— 写一份简短 skill 文档
 
-Create `.claude/skills/dev-local/SKILL.md` (or the repo's skills location) with:
-frontmatter (`name: dev-local`, a `description` listing trigger phrases), a
-service/port table, prerequisites, the subcommand list, and brief
-troubleshooting (port-in-use, a window exited, infra not running). Keep it to one
-screen — it documents the script, it doesn't re-explain it.
+创建 `.claude/skills/dev-local/SKILL.md`（或仓库的 skills 位置），包含：
+frontmatter（`name: dev-local`、列出触发短语的 `description`）、
+服务/端口表、前置条件、子命令列表，以及简短的
+故障排查（端口占用、某窗口退出、基础设施未运行）。控制在一屏内 —— 它记录脚本，不重新解释脚本。
 
-## Step 4 — Hand off
+## 第 4 步 —— 交接
 
-Tell the user the exact commands: `scripts/dev-local.sh up`, plus any first-run
-step (`… migrate`). List the URLs. Note any prerequisite they must install or
-start (e.g. Docker Desktop) before the first `up`.
+告诉用户确切的命令：`scripts/dev-local.sh up`，外加任何首次运行
+步骤（`… migrate`）。列出 URL。记下首次 `up` 前他们必须安装或
+启动的任何前置（例如 Docker Desktop）。
 
-## Principles
+## 原则
 
-- **Discover, don't assume.** Ports and start commands come from the repo, never
-  from convention alone.
-- **Idempotent & safe to re-run.** No duplicate servers, no clobbered infra.
-- **Right-sized.** A 3-service monorepo with Postgres+Redis needs the full
-  skeleton; a single Vite app needs ~30 lines. Don't over-build.
-- **Never run servers or print secrets.** Generate, syntax-check, hand off.
+- **发现，不要假设。** 端口和启动命令来自仓库，绝不
+  仅凭约定。
+- **幂等且可安全重跑。** 不重复服务器，不破坏基础设施。
+- **尺寸合适。** 一个带 Postgres+Redis 的 3 服务 monorepo 需要完整
+  骨架；单个 Vite 应用约 30 行。不要过度搭建。
+- **绝不运行服务器或打印密钥。** 生成、语法检查、交接。

--- a/.claude/skills/dev-local-setup/assets/dev-local.template.sh
+++ b/.claude/skills/dev-local-setup/assets/dev-local.template.sh
@@ -1,43 +1,43 @@
 #!/usr/bin/env bash
 #
-# dev-local.sh — bring this project's local dev stack up in one command.
+# dev-local.sh —— 一条命令把本项目的本地开发栈拉起来。
 #
-# TEMPLATE: replace every <PLACEHOLDER> with values discovered from the repo,
-# delete the parts you don't need (e.g. the whole infra section if there are no
-# DB/cache dependencies), and add a window per long-lived dev server.
+# 模板：用从仓库发现的值替换每个 <PLACEHOLDER>，
+# 删除你不需要的部分（例如没有 DB/缓存依赖时删掉整个 infra 段），
+# 并为每个长期运行的 dev 服务器加一个窗口。
 #
-# Usage:
-#   scripts/dev-local.sh up            # start infra + all dev servers (idempotent)
-#   scripts/dev-local.sh down          # stop the dev servers (leaves infra running)
-#   scripts/dev-local.sh down --all    # also stop infra
-#   scripts/dev-local.sh status        # window list + port check
-#   scripts/dev-local.sh logs <name>   # tail a window
+# 用法:
+#   scripts/dev-local.sh up            # 启动 infra + 所有 dev 服务器（幂等）
+#   scripts/dev-local.sh down          # 停止 dev 服务器（保留 infra 运行）
+#   scripts/dev-local.sh down --all    # 同时停止 infra
+#   scripts/dev-local.sh status        # 窗口列表 + 端口检查
+#   scripts/dev-local.sh logs <name>   # tail 某个窗口
 #   scripts/dev-local.sh restart <name>
-#   scripts/dev-local.sh attach        # attach to the tmux session
+#   scripts/dev-local.sh attach        # 接入 tmux 会话
 #
 set -euo pipefail
 
-# --- config -----------------------------------------------------------------
+# --- 配置 -----------------------------------------------------------------
 SESSION="<PROJECT>-dev"
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # repo root (script lives in scripts/)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # 仓库根（脚本在 scripts/ 下）
 
-# service-name -> port, for the port check. Fill from discovery.
-#   e.g. WEB_PORT=3000 ; API_PORT=4000
+# 服务名 -> 端口，用于端口检查。按发现结果填入。
+#   例如 WEB_PORT=3000 ; API_PORT=4000
 # <PORTS HERE>
 
-# Long-lived servers: "window_name|start command". One per service.
+# 长期运行的服务器："窗口名|启动命令"。每个服务一个。
 SERVERS=(
   # "web|pnpm --filter <web> run dev"
   # "api|pnpm --filter <api> run dev"
 )
 
-# Infra containers/ports to verify in `status` (name:port). Empty if none.
+# 要在 `status` 中验证的 infra 容器/端口（名:端口）。无则留空。
 INFRA_PORTS=(
   # "postgres:5432"
   # "redis:6379"
 )
 
-# --- pretty print -----------------------------------------------------------
+# --- 美化输出 -------------------------------------------------------------
 c_reset=$'\033[0m'; c_dim=$'\033[2m'; c_grn=$'\033[32m'; c_ylw=$'\033[33m'; c_red=$'\033[31m'; c_cyn=$'\033[36m'
 say()  { printf "%s\n" "$*"; }
 info() { printf "${c_cyn}▸ %s${c_reset}\n" "$*"; }
@@ -48,32 +48,32 @@ port_up() { lsof -ti :"$1" -sTCP:LISTEN >/dev/null 2>&1; }
 
 # --- preflight --------------------------------------------------------------
 preflight() {
-  command -v tmux >/dev/null 2>&1 || die "tmux not found. Install: brew install tmux"
-  command -v <PKG_MANAGER> >/dev/null 2>&1 || die "<PKG_MANAGER> not found."
-  # If infra needs Docker, uncomment:
-  # command -v docker >/dev/null 2>&1 || die "docker not found."
-  # docker info >/dev/null 2>&1 || die "Docker daemon not running. Start Docker Desktop."
-  [ -d "$ROOT/node_modules" ] || die "Deps not installed. Run: <PKG_MANAGER> install"
+  command -v tmux >/dev/null 2>&1 || die "未找到 tmux。安装: brew install tmux"
+  command -v <PKG_MANAGER> >/dev/null 2>&1 || die "未找到 <PKG_MANAGER>。"
+  # 如果 infra 需要 Docker，取消注释:
+  # command -v docker >/dev/null 2>&1 || die "未找到 docker。"
+  # docker info >/dev/null 2>&1 || die "Docker 守护进程未运行。启动 Docker Desktop。"
+  [ -d "$ROOT/node_modules" ] || die "依赖未安装。运行: <PKG_MANAGER> install"
 }
 
-# --- infra (delete this whole section if the repo has no infra deps) --------
+# --- infra（若仓库无 infra 依赖，整段删除） --------
 ensure_infra() {
-  # Example: start a Redis container if its port is free.
+  # 示例：端口空闲时启动一个 Redis 容器。
   # if ! port_up 6379; then
   #   docker start <PROJECT>-redis >/dev/null 2>&1 \
   #     || docker run -d --name <PROJECT>-redis -p 6379:6379 redis:7-alpine >/dev/null
-  #   ok "Redis up on :6379"
+  #   ok "Redis 已在 :6379 启动"
   # fi
-  # Example: local Supabase / docker-compose.
-  # ( cd "$ROOT" && supabase start )           # or: docker compose up -d
+  # 示例：本地 Supabase / docker-compose。
+  # ( cd "$ROOT" && supabase start )           # 或: docker compose up -d
   :
 }
 
-# --- tmux helpers -----------------------------------------------------------
-start_window() {  # idempotent: skip if the window already exists
+# --- tmux 辅助 -----------------------------------------------------------
+start_window() {  # 幂等：窗口已存在则跳过
   local name="$1" cmd="$2"
   if tmux list-windows -t "$SESSION" -F '#{window_name}' 2>/dev/null | grep -qx "$name"; then
-    warn "window '$name' already exists — leaving it alone"; return
+    warn "窗口 '$name' 已存在 —— 不动它"; return
   fi
   tmux new-window -t "$SESSION" -n "$name" -c "$ROOT"
   tmux send-keys -t "$SESSION:$name" "$cmd" C-m
@@ -81,7 +81,7 @@ start_window() {  # idempotent: skip if the window already exists
 
 port_check() {
   [ ${#INFRA_PORTS[@]} -eq 0 ] && return
-  say "  Port status (${c_dim}· = still starting${c_reset}):"
+  say "  端口状态（${c_dim}· = 仍在启动${c_reset}）:"
   for e in "${INFRA_PORTS[@]}"; do
     local nm="${e%%:*}" pt="${e##*:}"
     if port_up "$pt"; then printf "    ${c_grn}●${c_reset} %-14s :%s\n" "$nm" "$pt"
@@ -89,40 +89,40 @@ port_check() {
   done
 }
 
-# --- commands ---------------------------------------------------------------
+# --- 命令 ---------------------------------------------------------------
 cmd_up() {
   preflight
   ensure_infra
   tmux has-session -t "$SESSION" 2>/dev/null || tmux new-session -d -s "$SESSION" -n _bootstrap -c "$ROOT"
   for s in "${SERVERS[@]}"; do start_window "${s%%|*}" "${s#*|}"; done
   tmux kill-window -t "$SESSION:_bootstrap" 2>/dev/null || true
-  echo; ok "Stack starting in tmux session '$SESSION'."; echo
+  echo; ok "栈正在 tmux 会话 '$SESSION' 中启动。"; echo
   port_check
   echo
-  say "${c_dim}  Logs:   scripts/dev-local.sh logs <name>${c_reset}"
-  say "${c_dim}  Attach: scripts/dev-local.sh attach   (Ctrl-b d to detach)${c_reset}"
-  say "${c_dim}  Stop:   scripts/dev-local.sh down${c_reset}"
+  say "${c_dim}  日志:   scripts/dev-local.sh logs <name>${c_reset}"
+  say "${c_dim}  接入:   scripts/dev-local.sh attach   （Ctrl-b d 脱离）${c_reset}"
+  say "${c_dim}  停止:   scripts/dev-local.sh down${c_reset}"
 }
 
 cmd_status() {
   if tmux has-session -t "$SESSION" 2>/dev/null; then
-    info "tmux '$SESSION' windows:"
+    info "tmux '$SESSION' 窗口:"
     tmux list-windows -t "$SESSION" -F '    #{window_index}: #{window_name}'
-  else warn "session '$SESSION' not running"; fi
+  else warn "会话 '$SESSION' 未运行"; fi
   echo; port_check
 }
 
-cmd_logs()    { tmux has-session -t "$SESSION" 2>/dev/null || die "session not running"; tmux capture-pane -p -S -400 -t "$SESSION:${1:?usage: logs <name>}"; }
-cmd_restart() { tmux has-session -t "$SESSION" 2>/dev/null || die "session not running"
-  local n="${1:?usage: restart <name>}"; tmux kill-window -t "$SESSION:$n" 2>/dev/null || true
-  for s in "${SERVERS[@]}"; do [ "${s%%|*}" = "$n" ] && start_window "$n" "${s#*|}" && { ok "restarted $n"; return; }; done
-  die "unknown window '$n'"; }
-cmd_attach()  { tmux has-session -t "$SESSION" 2>/dev/null || die "not running — start with: dev-local.sh up"; tmux attach -t "$SESSION"; }
+cmd_logs()    { tmux has-session -t "$SESSION" 2>/dev/null || die "会话未运行"; tmux capture-pane -p -S -400 -t "$SESSION:${1:?用法: logs <name>}"; }
+cmd_restart() { tmux has-session -t "$SESSION" 2>/dev/null || die "会话未运行"
+  local n="${1:?用法: restart <name>}"; tmux kill-window -t "$SESSION:$n" 2>/dev/null || true
+  for s in "${SERVERS[@]}"; do [ "${s%%|*}" = "$n" ] && start_window "$n" "${s#*|}" && { ok "已重启 $n"; return; }; done
+  die "未知窗口 '$n'"; }
+cmd_attach()  { tmux has-session -t "$SESSION" 2>/dev/null || die "未运行 —— 用: dev-local.sh up 启动"; tmux attach -t "$SESSION"; }
 cmd_down() {
-  tmux kill-session -t "$SESSION" 2>/dev/null && ok "dev servers stopped" || warn "no session '$SESSION'"
+  tmux kill-session -t "$SESSION" 2>/dev/null && ok "dev 服务器已停止" || warn "无会话 '$SESSION'"
   if [ "${1:-}" = "--all" ]; then
-    : # stop infra here, e.g. docker stop <PROJECT>-redis ; ( cd "$ROOT" && supabase stop )
-    warn "infra teardown: fill in cmd_down --all for this repo"
+    : # 在这里停 infra，例如 docker stop <PROJECT>-redis ; ( cd "$ROOT" && supabase stop )
+    warn "infra 拆除: 为本仓库填好 cmd_down --all"
   fi
 }
 
@@ -134,5 +134,5 @@ case "${1:-up}" in
   restart) cmd_restart "${2:-}" ;;
   attach)  cmd_attach ;;
   -h|--help|help) awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next}{exit}' "${BASH_SOURCE[0]}" ;;
-  *) die "unknown command '$1' (try: up|down|status|logs|restart|attach)" ;;
+  *) die "未知命令 '$1'（可选: up|down|status|logs|restart|attach）" ;;
 esac

--- a/.claude/skills/e2e-setup/SKILL.md
+++ b/.claude/skills/e2e-setup/SKILL.md
@@ -1,64 +1,63 @@
 ---
 name: e2e-setup
 description: >
-  Set up an end-to-end test suite in any repo, following practices that make e2e a
-  reliable per-PR gate: real flows over bypass, layered assertions, a reusable
-  auth/session helper, video+trace evidence, and a compounding suite. Use when a
-  repo has no e2e (or weak e2e) and you want system-level tests — "set up e2e",
-  "add end-to-end tests", "scaffold a test gate".
+  在任意仓库搭建端到端测试套件，遵循让 e2e 成为可靠 per-PR 门禁的实践：真实流程优于
+  旁路、分层断言、可复用的 auth/session helper、视频+trace 证据、以及会复利的套件。当仓库没有
+  e2e（或 e2e 很弱）而你想要系统级测试时使用 —— "搭建 e2e"、
+  "加端到端测试"、"脚手架生成一个测试门禁"。
 user_invocable: true
 ---
 
-# Set up an e2e test suite
+# 搭建 e2e 测试套件
 
-E2e tests verify the whole running system *through the app* (browser/API), not one
-module. They are the per-PR gate. Pairs with `dev-local-setup` (a reproducible
-local stack) and `pr` (the verify→ship loop).
+E2e 测试*通过应用*（浏览器/API）验证整个运行中的系统，而不是某一个
+模块。它们是 per-PR 的门禁。与 `dev-local-setup`（可复现的
+本地栈）和 `pr`（验证→交付循环）配对。
 
-## Where it lives
-- **Unit/integration tests** stay inside each app/package — they own one module.
-- **System e2e** is a dedicated top-level package (e.g. `e2e/`) — it spans all
-  apps, so it belongs to none. Add it to the workspace if a monorepo.
+## 它放在哪
+- **单元/集成测试**留在每个 app/package 内部 —— 它们拥有一个模块。
+- **系统 e2e** 是一个独立的顶层 package（例如 `e2e/`）—— 它横跨所有
+  app，因此不属于任何一个。monorepo 则加入 workspace。
 
-## The recipe
-1. Stand the app up reproducibly — see `dev-local-setup`. The e2e suite **never
-   boots the app itself**; it runs against the already-running stack.
-2. Pick the framework that fits (Playwright for browser; your HTTP client for API).
-   Turn on **video + trace** — the recording is the proof, and it's gitignored output.
-3. **Explore the flow live first** (don't guess selectors), then crystallize it into
-   a committed spec.
-4. Keep the gate **small**: a handful of critical journeys, deterministic. Each new
-   feature PR adds its spec — the suite compounds.
+## 配方
+1. 可复现地把应用立起来 —— 见 `dev-local-setup`。e2e 套件**绝不
+   自己启动应用**；它跑在已经起来的栈上。
+2. 选合适的框架（浏览器用 Playwright；API 用你的 HTTP client）。
+   打开 **video + trace** —— 录像是证据，且它是 gitignored 输出。
+3. **先实时探查流程**（不要猜选择器），再把它固化成一份
+   已提交的 spec。
+4. 让门禁**小**：少数关键旅程，确定性。每个新
+   功能 PR 加它的 spec —— 套件复利增长。
 
-## Practices that make e2e trustworthy
-- **Real flow, not bypass.** Drive the genuine path. For email codes / OTP, read the
-  real code from a local mail server (Mailpit / Inbucket / MailHog) — never hardcode
-  a fixed test code. That's what makes it a test, not a rehearsal.
-- **Verify auth ITSELF once; bypass it everywhere else.** A dedicated signup/login
-  spec proves auth works. Every *other* spec shouldn't re-pay the login tax — build
-  a **session helper** that mints an authed state once (real flow → saved storage
-  state, or a service-role/token mint) and load it.
-- **Layered assertions: client → server → product.** Don't stop at "the UI changed."
-  Confirm the server agrees (token validates / row/state is right) AND the
-  user-visible outcome (e.g. plan upgraded *and* credits granted).
-- **Stable selectors.** Prefer role/label/text; add a small `data-testid` in the
-  component when there's no good handle — never a brittle CSS path.
-- **Fresh data per run.** Unique emails/ids so reruns don't collide; mind rate
-  limits (auth email, etc.).
-- **Commit specs + helpers, never `test-results/`** (generated output).
+## 让 e2e 值得信赖的实践
+- **真实流程，不走旁路。** 驱动真正的路径。邮件验证码 / OTP，从
+   本地邮件服务器（Mailpit / Inbucket / MailHog）读真实
+   验证码 —— 绝不硬编码固定测试码。这才是它成为测试而非彩排的原因。
+- **验证 auth 本身一次；其他处处旁路它。** 一个专门的 signup/login
+   spec 证明 auth 可用。每个*其他* spec 不该再付一次登录税 —— 建一个
+   **session helper**，一次 mint 出已认证状态（真实流程 → 保存的 storage
+   state，或一个 service-role/token mint）并加载。
+- **分层断言：client → server → product。** 别停在"UI 变了"。
+   确认服务端也一致（token 校验通过 / 行/状态正确）以及
+   用户可见结果（例如套餐升级*且*积分到账）。
+- **稳定选择器。** 优先 role/label/text；没有好抓手时在
+   组件里加一个 `data-testid` —— 绝不用脆弱的 CSS 路径。
+- **每次运行用全新数据。** 唯一 email/id 让重跑不冲突；注意
+   速率限制（auth 邮件等）。
+- **提交 spec + helper，绝不提交 `test-results/`**（生成输出）。
 
-## When a test fails: triage before "fixing"
-A red e2e is information. Classify first:
-- **Real bug** — the product broke. Fix the code; the test did its job.
-- **Stale test** — the flow intentionally changed (renamed route, new step). Update
-  the test to match the new contract.
-- **Flaky / env** — stack down, timing, rate limit, stale data. Fix robustness/env.
+## 测试失败时：先 triage 再"修"
+一条红的 e2e 是信息。先分类：
+- **真 bug** —— 产品坏了。修代码；测试尽到了职责。
+- **过时测试** —— 流程有意改了（重命名路由、新增步骤）。更新
+   测试以匹配新契约。
+- **Flaky / 环境** —— 栈没起、时序、速率限制、陈旧数据。修健壮性/环境。
 
-**Never weaken or delete an assertion just to go green.** Loosening is only correct
-when the *intended contract* changed — confirmed from the diff, not assumed.
+**绝不为变绿而削弱或删除断言。** 只有当*有意契约*变了时放松才正确
+—— 从 diff 确认，而非假设。
 
-## External services (payments, email, 3rd-party)
-Use the vendor's **test/sandbox mode**, never live keys — and **guard hard**: the
-test should refuse to run if it detects a live key/credential. If a webhook
-completes the flow, forward it locally (e.g. the vendor's CLI listener) so the e2e
-exercises the real fulfilment path, not a faked event.
+## 外部服务（支付、邮件、第三方）
+用厂商的**测试/沙箱模式**，绝不用 live key —— 而且**严防**：如果
+测试检测到 live key/凭据就应拒绝运行。如果一个 webhook
+完成流程，就把它转发到本地（例如厂商的 CLI listener），让 e2e
+演练真实的履约路径，而非伪造事件。

--- a/.claude/skills/new-loop/SKILL.md
+++ b/.claude/skills/new-loop/SKILL.md
@@ -1,87 +1,84 @@
 ---
 name: new-loop
-description: Spin up a new loop (domain) in this knowledge base — gather its charter, scaffold domains/<loop>/README.md, ensure the signals/ + docs/ substrate exists, then do ONE real test run of the loop and record it in the loop README's Timeline and in LOG.md. Use when the user says "set up a new loop", "create a domain", "start a new beat/workstream", or names a recurring job they want the agent to own.
+description: 在本知识库中启动一个新循环（domain）—— 收集它的章程、脚手架生成 domains/<loop>/README.md、确保 signals/ + docs/ 底座存在，然后对该循环做一次真实试运行，并记录到循环 README 的 Timeline 和 LOG.md。当用户说"设置一个新循环"、"创建一个 domain"、"开始一个新的 beat/workstream"，或点名一个他们希望 agent 接管的周期性工作时使用。
 ---
 
-# new-loop — spin up a new loop
+# new-loop —— 启动一个新循环
 
-A **loop** (a `domain`) is a recurring thread of work the agent owns: a charter, a cadence, and
-the artifacts it produces. This skill creates one, proves it works with a single real run, and
-leaves behind a `domains/<loop>/README.md` that is the loop's live state.
+一个**循环**（一个 `domain`）是 agent 拥有的一段周期性工作主线：一个章程、一个节奏、
+以及它产出的 artifact。这个 skill 创建一个循环、用一次真实运行证明它可用、并留下一个
+`domains/<loop>/README.md` 作为该循环的实时状态。
 
-Read `ARCHITECTURE.md` first if you haven't — it's the model this skill instantiates.
+如果你还没读过 `ARCHITECTURE.md`，先读 —— 它是这个 skill 实例化的模型。
 
-## When to use
-The user wants to stand up a new workstream/beat/job (e.g. "a weekly SEO loop", "a support
-triage loop", "a competitor-watch loop"). Don't use this for a one-off task — that's just a
-backlog line in an existing domain, or a `doc`/`signal`.
+## 何时使用
+用户想立起一个新的工作流/beat/任务（例如"一个每周 SEO 循环"、"一个客服 triage
+循环"、"一个竞品观察循环"）。不要把它用于一次性的任务 —— 那只是某个已有 domain 里的
+一行 backlog，或一个 `doc`/`signal`。
 
-## Inputs to gather (ask only what's missing)
-Pull these from the user's request; ask a short clarifying round only for what you can't infer:
+## 要收集的输入（只问缺失的）
+从用户的请求里提取这些；只对你无法推断的做一轮简短澄清：
 
-1. **name** — kebab-case, the loop's home folder (`domains/<name>/`). Keep it short.
-2. **goal** — one line: the outcome this loop drives.
-3. **cadence** — `manual` / `daily` / `weekly` / a cron expr. Default `manual`.
-4. **what it does** — what the loop consumes (signals? data? an inbox? a URL?) and produces
-   (signals? docs? a report? code changes via `ship-change`?).
-5. **tools/data** — any sources or credentials it needs (note them; point at a setup skill or
-   `.env` rather than inlining secrets).
+1. **name** —— kebab-case，循环的家文件夹（`domains/<name>/`）。保持简短。
+2. **goal** —— 一句话：这个循环要推动的结果。
+3. **cadence** —— `manual` / `daily` / `weekly` / 一个 cron 表达式。默认 `manual`。
+4. **它做什么** —— 循环消费什么（signal？数据？某个收件箱？某个 URL？）以及产出什么
+   （signal？doc？报告？通过 `ship-change` 的代码变更？）。
+5. **工具/数据** —— 它需要的任何来源或凭据（记下来；指向一个 setup skill 或
+   `.env`，而不是把密钥写进来）。
 
-If the request is already specific, infer all five and just confirm in your summary — don't
-interrogate.
+如果请求已经足够具体，就推断全部五项并在摘要里确认即可 —— 不要盘问。
 
-## Procedure
+## 流程
 
-### 1. Ensure the substrate exists
-From the repo root, make sure these exist (create the folder + copy the schema `README` from
-this kit if missing — don't recreate one that's already there):
-- `signals/README.md`, `docs/README.md` — the two starter kinds.
-- `domains/README.md` — the domain schema.
-- `LOG.md` — the global feed (with its header/grammar).
+### 1. 确保底座存在
+从仓库根目录，确认以下存在（缺失则创建文件夹并从本 kit 复制 schema `README`
+—— 已有的不要重建）：
+- `signals/README.md`、`docs/README.md` —— 两个启动类别。
+- `domains/README.md` —— domain schema。
+- `LOG.md` —— 全局信息流（带它的标题/语法）。
 
-Do **not** pre-create a `tasks/` folder or any other kind. Earn those later per `ARCHITECTURE.md`.
+**不要**预先创建 `tasks/` 文件夹或任何其他类别。按 `ARCHITECTURE.md` 后续再挣。
 
-### 2. Scaffold the loop README
-Create `domains/<name>/README.md` from the template in `domains/README.md`, filled with the
-gathered inputs. Required sections: frontmatter (`kind: domain`, `domain`, `status: active`,
-`goal`, `cadence`), a 2-4 line description, `## Current focus`, `## Backlog` (the loop's to-dos
-inline — these stay in the README until they earn a `task` kind), and an empty `## Timeline`.
-Add `## Evidence & analysis` and `## Metrics` placeholders if relevant.
+### 2. 脚手架生成循环 README
+用 `domains/README.md` 里的模板创建 `domains/<name>/README.md`，填入收集到的输入。
+必填章节：frontmatter（`kind: domain`、`domain`、`status: active`、
+`goal`、`cadence`）、2-4 行描述、`## Current focus`、`## Backlog`（循环的待办
+内联 —— 它们留在 README 里直到挣到 `task` 类别）、以及一个空的 `## Timeline`。
+相关时加 `## Evidence & analysis` 和 `## Metrics` 占位。
 
-Check for collisions: if `domains/<name>/` already exists, stop and ask whether to update it
-instead of overwriting.
+检查冲突：如果 `domains/<name>/` 已存在，停下并询问是更新它而不是覆盖。
 
-### 3. Do ONE real test run
-This is the point of the skill: prove the loop actually runs, not just that the folder exists.
+### 3. 做一次真实试运行
+这是这个 skill 的意义所在：证明循环真的能跑，而不只是文件夹存在。
 
-**Actually run the loop once, at small scale** — do whatever the loop is meant to do (triage a
-few real tickets, pull one real SERP, fetch the inbox, draft one comment, run one analysis
-query, scope one code change, …). Use the loop's real tools/data where you can; if a credential
-is missing, do the furthest-reachable dry run and note the gap.
+**真正小规模地运行一次循环** —— 做这个循环本该做的事（triage 几条真实 ticket、
+抓一个真实 SERP、拉收件箱、草拟一条评论、跑一个分析查询、scope 一个代码变更……）。
+尽量用循环真实的工具/数据；如果缺凭据，就做能到达的最远的一次 dry run 并记下差距。
 
-**Producing an artifact is optional.** A legitimate run may surface nothing worth filing — that's
-a real result, not a failure. Only create a `signal`/`doc` if the run genuinely produced one.
+**产出 artifact 是可选的。** 一次合法的运行可能什么值得归档的东西都没有 —— 那是
+真实结果，不是失败。只有当运行真的产出了 signal/doc 时才创建它。
 
-Whatever happens, the run has two **required** outputs:
-- Append one dated line to the loop README's `## Timeline`:
-  `YYYY-MM-DD | test run — <what you did and what you found / "nothing actionable yet">`.
-- Append one entry to `LOG.md` using its grammar:
+无论发生什么，运行有两个**必填**输出：
+- 向循环 README 的 `## Timeline` 追加一行带日期的记录：
+  `YYYY-MM-DD | 试运行 —— <你做了什么以及发现了什么 / "暂无可行动项">`。
+- 用其语法向 `LOG.md` 追加一条：
   ```
-  ## YYYY-MM-DD · <loop-name> loop created + first run · #ops
-  What: <one line — what the loop is and what the first run did/found>.
-  Refs: domains/<name>/README.md (new)[, any artifact created].
+  ## YYYY-MM-DD · <loop-name> 循环创建 + 首次运行 · #ops
+  What: <一行 —— 循环是什么以及首次运行做了/发现了什么>。
+  Refs: domains/<name>/README.md (new)[, 创建的任何 artifact]。
   ```
 
-### 4. Report back
-Summarize to the user: the loop's charter (the five inputs), what the test run did and found,
-any artifacts created (or "none — nothing actionable this run"), any missing tools/credentials
-to wire up, and how to run it again (the cadence + the entry point). Keep it tight.
+### 4. 汇报
+向用户摘要：循环的章程（那五项输入）、试运行做了和发现了什么、创建的任何
+artifact（或"无 —— 本次运行无可行动项"）、任何需要接上的缺失工具/凭据、以及如何
+再次运行它（节奏 + 入口）。保持精炼。
 
-## Notes
-- **Don't gold-plate the scaffold.** A loop README is live state, not a spec — start lean and
-  let it accrete via its Timeline.
-- **One loop = one separable workstream.** If what the user described is really part of an
-  existing loop, say so and add it there (a backlog line + a `domain:` tag) instead of creating
-  a near-duplicate domain.
-- For loops that ship code, the loop's "run" can drive the `ship-change` workflow
-  (`.claude/workflows/ship-change.js`) — point the README's Backlog at it.
+## 备注
+- **不要给脚手架镀金。** 循环 README 是实时状态，不是规格 —— 精简起步，让它通过
+  Timeline 自然积累。
+- **一个循环 = 一个独立工作流。** 如果用户描述的其实属于某个已有循环的一部分，就说
+  出来并加到那里（一行 backlog + 一个 `domain:` 标签），而不是创建一个近乎重复的
+  domain。
+- 对于交付代码的循环，循环的"运行"可以驱动 `ship-change` workflow
+  （`.claude/workflows/ship-change.js`）—— 把 README 的 Backlog 指向它。

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,92 +1,90 @@
 ---
 name: pr
 description: >
-  Prove the feature you just built actually works — a fresh verifier sub-agent
-  drives the real app — then open a pull request with the proof. Use when a change
-  is ready to ship in any repo — "open a PR", "ship this", "raise a PR", "/pr".
-  Never opens a PR until the feature is verified.
+  证明你刚构建的功能真的可用 —— 一个全新的 verifier 子 agent
+  驱动真实应用 —— 然后带着证据开 pull request。当某项变更
+  准备好在任意仓库交付时使用 —— "开个 PR"、"交付这个"、"提个 PR"、"/pr"。
+  功能未通过验证前绝不开 PR。
 user_invocable: true
 ---
 
-# /pr — prove the feature works, then open the PR
+# /pr —— 先证明功能可用，再开 PR
 
-You are the **orchestrator + fixer**. Verification splits by who's best at it:
+你是**编排者 + 修复者**。验证按谁最擅长来分工：
 
-- **The subjective question — "does the feature I just built do what was
-  intended?"** → delegate to a fresh **verifier sub-agent** that drives the real
-  app and judges it. Independence (it didn't write the code) + context-isolation
-  (app-driving is verbose) pay off here. Most new features have no spec — this is
-  **agentic verification, not "run the test."** Do it first.
-- **Objective, codified checks** (type-check, lint, unit, existing e2e) → **you**
-  run them, after, as a regression sweep. Pass/fail can't be rubber-stamped, so
-  delegating buys nothing but a round-trip — and you need the error to fix it.
+- **主观问题 —— "我刚构建的功能是否做到了预期？"** → 委派给一个全新的
+  **verifier 子 agent**，它驱动真实应用并做判断。独立性（它没写过这段代码）+ 上下文隔离
+  （驱动应用输出很啰嗦）在这里有回报。大多数新功能没有规格 —— 这是
+  **agentic 验证，不是"跑测试"。** 先做它。
+- **客观的、固化的检查**（type-check、lint、单元、已有 e2e）→ **你**
+  之后跑，作为回归扫描。通过/失败没法盖橡皮章，所以委派
+  只换来一次往返 —— 而且你需要错误来修。
 
-Pairs with `dev-local-setup` (reproducible stack) and `e2e-setup` (the suite).
+与 `dev-local-setup`（可复现栈）和 `e2e-setup`（套件）配对。
 
-## 1. Preconditions
-On a branch, not the default branch; changes committed.
+## 1. 前置条件
+在一个分支上，不在默认分支上；变更已提交。
 
-## 2. Bring up the stack — once
-Start it via your repo's dev launcher (see `dev-local-setup`). You own it; the
-verifier reuses it.
+## 2. 把栈立起来 —— 一次
+通过仓库的 dev 启动器启动它（见 `dev-local-setup`）。你拥有它；verifier
+复用它。
 
-## 3. Verify the FEATURE (delegate) → fix → re-verify (loop)
-Brief from the plan file if one exists (point the verifier at it), else pass the
-requirements inline. Spawn a read-only verifier:
+## 3. 验证功能（委派）→ 修 → 再验证（循环）
+如果存在 plan 文件就从它简报（把 verifier 指向它），否则内联传
+需求。派生一个只读 verifier：
 
 ```
-You are a read-only verifier. Do NOT edit code. Independently confirm THIS feature
-works by driving the running app (the stack is already up). It likely has no
-automated spec — verify it agentically.
+你是一个只读 verifier。不要改代码。通过驱动运行中的应用独立确认这个功能
+可用（栈已起来）。它很可能没有自动化 spec —— 用 agentic 方式验证它。
 
-FEATURE (what a user should now be able to do, and the observable success state):
-  <intent / acceptance criteria>          (or: see plan file <path>)
+FEATURE（用户现在应能做什么，以及可观察的成功状态）：
+  <意图 / 验收标准>          （或：见 plan 文件 <path>）
 HOW TO EXERCISE IT:
-  <UI route + steps / API call / CLI>
-AUTH (if the feature is behind login):
-  mint a session first via the repo's session helper and load it before driving.
+  <UI 路由 + 步骤 / API 调用 / CLI>
+AUTH（如果功能在登录后）:
+  先通过仓库的 session helper mint 一个会话，加载后再驱动。
 
-Drive it (browser via playwright-cli, or the API/CLI): walk the exact steps,
-screenshot/record the success state, judge observed vs expected. Return ONLY:
+驱动它（通过 playwright-cli 用浏览器，或 API/CLI）：走精确步骤，
+截屏/录制成功状态，判断观察到的 vs 预期。只返回：
 
 FEATURE: works | broken
-  expected: <criteria>
-  observed: <what actually happened>
-  evidence: <screenshot/video paths>
+  expected: <标准>
+  observed: <实际发生了什么>
+  evidence: <截屏/视频路径>
 ```
 
-- **broken** → fix the implementation, then spawn a **fresh** verifier. You never
-  declare the feature works yourself.
-- Cap at ~3 rounds; if still broken, escalate to the human with the verdict.
+- **broken** → 修实现，然后派生一个**全新** verifier。你绝不
+  自己宣布功能可用。
+- 上限约 3 轮；仍 broken 则带结论上报人类。
 
-## 4. Regression sweep — you run the codified checks; fix red directly
-type-check · lint · unit · existing e2e. Triage failures (real-bug vs stale-test —
-see `e2e-setup`); never weaken an assertion to go green. If a fix here changes
-feature behavior, re-verify (step 3).
+## 4. 回归扫描 —— 你跑固化的检查；红了直接修
+type-check · lint · 单元 · 已有 e2e。Triage 失败（真 bug vs 过时测试 ——
+见 `e2e-setup`）；绝不为变绿而削弱断言。如果这里的修复改变了
+功能行为，回到第 3 步重验。
 
-## 5. Open the PR — lead with the feature proof
-Get a **reviewable link** for the success video. GitHub can't play video inline via
-automation, so upload it somewhere with a stable URL — a dedicated `pr-evidence`
-GitHub prerelease (`gh release upload`), a bucket, or CI artifacts — and link it.
+## 5. 开 PR —— 以功能证据开头
+为成功视频拿到一个**可 review 的链接**。GitHub 无法通过自动化内联播放视频，
+所以把它传到一个有稳定 URL 的地方 —— 一个专门的 `pr-evidence`
+GitHub prerelease（`gh release upload`）、一个 bucket，或 CI artifacts —— 然后链接它。
 
 ```markdown
 ## What changed
-<1–3 lines>
+<1–3 行>
 
-## Feature verified ✅  (verifier drove the app)
-- <acceptance criteria> — observed working.  📹 Proof: <url>
+## Feature verified ✅  (verifier 驱动了应用)
+- <验收标准> —— 观察到可用。  📹 证据: <url>
 
 ## Regression guardrails
-- [x] type-check · lint · unit · e2e
+- [x] type-check · lint · 单元 · e2e
 
 ## How to reproduce
-<stack-up command> && <exercise steps>
+<栈启动命令> && <演练步骤>
 ```
 
-## Rules
-- **The feature is the verdict** — a green suite with an unverified feature isn't done.
-- **"Does it actually work" → an independent verifier; objective checks → you.**
-- Never open a PR until the feature is verified. **Proof, not claims.** Branch → PR only.
+## 规则
+- **功能就是结论** —— 套件全绿但功能未验证，不算完成。
+- **"它真的可用吗" → 独立 verifier；客观检查 → 你。**
+- 功能未通过验证前绝不开 PR。**要证据，不要声明。** 分支 → PR 才行。
 
-> Isolates *context*, not *environment*: if your stack is single-instance /
-> fixed-port, don't run multiple verifiers in parallel.
+> 隔离的是*上下文*，不是*环境*：如果你的栈是单实例 /
+> 固定端口，不要并行跑多个 verifier。

--- a/.claude/skills/setup-codebase-harness/SKILL.md
+++ b/.claude/skills/setup-codebase-harness/SKILL.md
@@ -1,90 +1,83 @@
 ---
 name: setup-codebase-harness
 description: >
-  Master skill — set up the full agent harness for any repo so an agent can work
-  it reliably: legible (map-not-manual docs + custom lints), executable
-  (one-command dev stack), verifiable (e2e gate + a verify-before-ship loop), plus
-  commit hygiene and entropy control. Use when onboarding a new/unfamiliar codebase
-  to agent-driven development — "set up the harness", "make this repo agent-ready",
-  "harness this codebase".
+  主 skill —— 为任意仓库装配完整的 agent harness，让 agent 能可靠地工作于其上：
+  可读（地图而非手册的文档 + 自定义 lint）、可执行（一条命令的开发栈）、可验证
+  （e2e 门禁 + 先验证再交付的循环），外加提交卫生与熵控制。当要把一个新/陌生的
+  代码库接入 agent 驱动开发时使用 —— "装配 harness"、"让这个仓库对 agent 可用"、
+  "给这个代码库装 harness"。
 user_invocable: true
 ---
 
-# Set up the codebase harness
+# 装配代码库 harness
 
-**Harness engineering:** the model is fixed — what you engineer is the *scaffolding*
-around it (the environment, the docs, the feedback loops) so an agent can build and
-verify software with minimal human attention. Humans steer; agents execute. Your
-job is to make the repo **legible, executable, and verifiable.**
+**Harness 工程：** 模型是固定的 —— 你工程化的是它周围的*脚手架*
+（环境、文档、反馈回路），让 agent 能以最少的人力关注来构建和
+验证软件。人类掌舵；agent 执行。你的
+工作是让仓库**可读、可执行、可验证。**
 
-Work **incrementally and depth-first**: assess what exists, build the one missing
-capability, use it to unlock the next. Don't boil the ocean — set up what the repo
-actually needs. When the agent struggles, the fix is almost never "try harder" —
-ask *"what capability is missing, and how do I make it legible and enforceable?"*
-and add it.
+**增量地、深度优先地**工作：评估现有、搭建那一个缺失的
+能力、用它解锁下一步。不要试图煮干大海 —— 只装配仓库真正需要的。当 agent 卡住时，解决办法几乎从不是"再努力点" ——
+问*"缺什么能力，我怎么让它可读且可强制执行？"*然后加上它。
 
-This skill orchestrates the focused sub-skills: **`dev-local-setup`**,
-**`e2e-setup`**, **`pr`**.
+这个 skill 编排几个聚焦的子 skill：**`dev-local-setup`**、
+**`e2e-setup`**、**`pr`**。
 
-## 0. Assess
+## 0. 评估
 
-Survey the repo: stack, package manager, services/ports, infra deps, existing
-docs/tests/CI, and the *implicit* rules (buried in READMEs, PR comments, people's
-heads). Note what's missing per pillar below.
+勘察仓库：技术栈、包管理器、服务/端口、基础设施依赖、现有
+文档/测试/CI，以及*隐式*规则（埋在 README、PR 评论、人们脑子里的）。按下面的
+支柱记下缺什么。
 
-## 1. Legible — the agent can reason about the repo
+## 1. 可读 —— agent 能对仓库进行推理
 
-> What the agent can't see doesn't exist. Knowledge in chat threads / heads is
-> invisible — push it into versioned, repo-local artifacts.
+> agent 看不见的东西就不存在。聊天记录/脑子里的知识是
+> 不可见的 —— 把它们推进到版本化、仓库本地的 artifact 里。
 
-- **a) Map, not manual.** Shrink the root agent doc (`AGENTS.md` / `CLAUDE.md`) to a
-  ~100-line **table of contents**: one-line overview, project tree, **golden rules**
-  (the hard invariants), and a "where to look" table. Move the depth into a
-  structured **`docs/` system-of-record** (architecture, frontend, testing, domain
-  topics) with a `docs/index.md`. A monolithic instruction file rots and crowds out
-  the task — keep the map small and stable, disclose detail progressively.
-- **b) Custom lints with remediation.** Promote the prose golden rules into
-  **mechanical checks** — human taste captured once, enforced everywhere, every run.
-  One lint per invariant (layering / dependency direction, naming, no-`any`,
-  forbidden imports, file-size, structured logging). **Write the error message to
-  inject the fix** ("X isn't allowed here — do Y") so the remediation lands in agent
-  context. Wire them into the repo's linter + CI.
-- **c) (later) Keep docs honest.** A freshness / doc-gardening pass that flags docs
-  that no longer match the code and opens fix-up PRs.
+- **a) 地图，不是手册。** 把根 agent 文档（`AGENTS.md` / `CLAUDE.md`）缩到一份
+  ~100 行的**目录**：一行概述、项目树、**金科玉律**
+  （硬性不变量），以及一张"去哪看"的表。把深度移到一个结构化的**`docs/` 事实来源**
+  （架构、前端、测试、领域话题），带一个 `docs/index.md`。一个臃肿的指令文件会
+  腐烂并挤占任务空间 —— 让地图小而稳定，渐进地披露细节。
+- **b) 带修复指引的自定义 lint。** 把散文式的金科玉律提升为
+  **机械检查** —— 人类品味一次捕获，处处、每次运行强制执行。
+  一个不变量一条 lint（分层 / 依赖方向、命名、禁 `any`、
+  禁止的 import、文件大小、结构化日志）。**把修复方式写进错误信息**
+  （"X 不允许在这里 —— 改做 Y"），让修复直接落到 agent 上下文里。把它们接到仓库的 linter + CI。
+- **c)（之后）让文档保持诚实。** 一次新鲜度 / 文档养护 pass，标记不再
+  匹配代码的文档并开修复 PR。
 
-## 2. Executable — the agent can run & drive the app
+## 2. 可执行 —— agent 能运行并驱动应用
 
-- **`dev-local-setup`** → a one-command, reproducible local stack
-  (`scripts/dev-local.sh up`) running every service + infra.
-- Make the app **drivable**: browser via the `playwright-cli` skill; logs reachable.
-- *Advanced:* boot the app **per git worktree** so parallel agents don't collide; a
-  local, ephemeral observability stack (queryable logs/metrics) for perf/reliability
-  prompts.
+- **`dev-local-setup`** → 一条命令、可复现的本地栈
+  （`scripts/dev-local.sh up`）跑起每个服务 + 基础设施。
+- 让应用**可驱动**：通过 `playwright-cli` skill 操作浏览器；日志可触达。
+- *进阶：* 按 git worktree 启动应用，让并行 agent 不冲突；一个
+  本地、临时的可观测性栈（可查询的日志/指标）用于性能/可靠性
+  提示。
 
-## 3. Verifiable — the agent can prove it works
+## 3. 可验证 —— agent 能证明它可用
 
-- **`e2e-setup`** → a trustworthy e2e gate: real flows (not bypass), a reusable
-  auth/session helper, layered client → server → product assertions, video/trace
-  evidence, sandbox-only external services.
-- **`pr`** → the verify-before-ship loop: a fresh **verifier sub-agent drives the
-  real app** to confirm the just-built feature works; the main agent fixes until
-  green, runs the codified regression sweep, and opens a PR with a reviewable proof
-  link. Add the session helper so the verifier can reach login-gated features.
+- **`e2e-setup`** → 一个值得信赖的 e2e 门禁：真实流程（不走旁路）、一个可复用
+  的 auth/session helper、分层 client → server → product 断言、视频/trace
+  证据、仅沙箱的外部服务。
+- **`pr`** → 先验证再交付循环：一个全新的 **verifier 子 agent 驱动
+  真实应用**确认刚构建的功能可用；主 agent 修到全绿、跑固化的回归
+  扫描，并开一个带可 review 证据链接的 PR。加上 session helper，让 verifier 能触及登录门后的功能。
 
-## 4. Others — keep it coherent over time
+## 4. 其他 —— 让它在时间中保持一致
 
-- **Commit hygiene**: conventional commits + format/lint on commit (e.g. husky
-  lint-staged + commitlint). Keep merge gates **light** — at high agent throughput,
-  corrections are cheap and waiting is expensive.
-- **Garbage collection**: encode "golden principles", then run periodic cleanup
-  passes that open small refactor PRs — pay tech debt down continuously, not in
-  painful bursts. Human taste captured once, enforced on every line.
-- **Agent-to-agent review** for correctness-critical changes (independent reviewers,
-  not self-review).
+- **提交卫生**：约定式提交 + 提交时 format/lint（例如 husky
+  lint-staged + commitlint）。让合并门禁**轻量** —— 在高 agent 吞吐下，
+  修正很便宜，等待很昂贵。
+- **垃圾回收**：编码"金科玉律"，然后跑周期性清理
+  pass 开小重构 PR —— 持续地还技术债，而不是
+  痛苦地集中爆发。人类品味一次捕获，每行强制执行。
+- **agent 间 review** 用于正确性关键的变更（独立 review 者，
+  而非自审）。
 
-## Order & what you leave behind
+## 顺序与留下的东西
 
-**1a (map) → 2 (dev-local) → 3 (e2e + /pr)**, then **1b (lints)** and **4** as the
-repo matures. The artifacts — slim map + `docs/`, `scripts/dev-local.sh`, an `e2e/`
-suite, the `/pr` skill, and custom lints — are each a reusable, legible capability
-that compounds. Prefer "boring", composable, stable tech the agent can fully model.
+**1a（地图）→ 2（dev-local）→ 3（e2e + /pr）**，然后随着仓库成熟做
+**1b（lint）** 和 **4**。留下的 artifact —— 精简的地图 + `docs/`、`scripts/dev-local.sh`、
+一套 `e2e/`、`/pr` skill、以及自定义 lint —— 每一个都是可复用、可读、会复利的能力。偏好"无聊"、可组合、稳定、agent 能完全建模的技术。

--- a/.claude/workflows/ship-change.js
+++ b/.claude/workflows/ship-change.js
@@ -1,9 +1,9 @@
 export const meta = {
   name: 'ship-change',
   description:
-    'Ship a focused code change end-to-end: create an isolated worktree, implement, simplify, review+fix blocking issues, verify locally, then open a PR (PR only if verification passes). Uses Codex for the review pass if it is available, and degrades to a normal review agent if not. If the target repo ships its own /pr skill, the verify+PR step is delegated to it.',
+    '端到端交付一个聚焦的代码变更：创建隔离 worktree、实现、简化、review+修阻塞性问题、本地验证，然后开 PR（仅在验证通过时）。如果有 Codex 可用则用于 review pass，否则降级为普通 review agent。如果目标仓库自带 /pr skill，则验证+PR 步骤委派给它。',
   whenToUse:
-    'A scoped change on an existing repo that should end in a PR. Pass args.task (what to build), args.repo (abs path). Optional: baseBranch, branch, verifyHints, openPr, runReview.',
+    '一个在已有仓库上、应以 PR 收尾的范围明确变更。传入 args.task（要构建什么）、args.repo（绝对路径）。可选：baseBranch、branch、verifyHints、openPr、runReview。',
   phases: [
     { title: 'Setup' },
     { title: 'Implement' },
@@ -24,10 +24,10 @@ if (!TASK || !REPO) {
   )
 }
 const BASE = a.baseBranch || 'main'
-const BRANCH_HINT = a.branch || '' // empty → Setup agent derives one
+const BRANCH_HINT = a.branch || '' // 空 → Setup agent 派生一个
 const VERIFY_HINTS = a.verifyHints || ''
-const OPEN_PR = a.openPr !== false // default true
-// review pass defaults on; accepts runReview, and runCodex for backward-compat
+const OPEN_PR = a.openPr !== false // 默认 true
+// review pass 默认开启；接受 runReview，以及为向后兼容接受 runCodex
 const RUN_REVIEW = a.runReview !== false && a.runCodex !== false
 
 // ───────────────────────── Phase 0: Setup (worktree) ─────────────────────────
@@ -46,62 +46,62 @@ const SETUP_SCHEMA = {
   },
 }
 const setup = await agent(
-  `Create an isolated git worktree to do an upcoming change in, WITHOUT disturbing the user's main checkout of the repo.
+  `创建一个隔离的 git worktree，用于做接下来的变更，且不打扰用户对仓库的主检出。
 
-Repo: ${REPO}
-Base branch: ${BASE}
-Desired feature branch: ${BRANCH_HINT || '(none given — derive a short, kebab-case, conventional branch name from the task below)'}
-Task the worktree is for (for branch-name derivation only — do NOT implement anything yet):
+仓库: ${REPO}
+基线分支: ${BASE}
+期望的功能分支: ${BRANCH_HINT || '（未提供 —— 从下方任务派生一个简短的 kebab-case 约定式分支名）'}
+该 worktree 所服务的任务（仅用于派生分支名 —— 暂不要实现任何东西）:
 """
 ${TASK}
 """
 
-Steps:
-1. cd ${REPO}. Run \`git fetch origin --prune\` (ignore failure if offline). Determine the freshest base ref: prefer \`origin/${BASE}\` if it exists, else local \`${BASE}\`.
-2. Pick the feature branch name (use the given one if provided, else derive e.g. feat/<slug> or fix/<slug>). Make sure it does not already exist (append -2 etc. if needed).
-3. Choose a worktree path OUTSIDE the main checkout: a sibling dir like \`<repo>-worktrees/<branch-slug>\` (create the parent dir if needed). Avoid nesting inside the repo.
-4. Create it: \`git -C ${REPO} worktree add <worktreePath> -b <branch> <baseRef>\`.
-5. Verify: the worktree path exists, \`git -C <worktreePath> rev-parse --abbrev-ref HEAD\` shows the new branch, and \`git -C <worktreePath> status\` is clean.
-6. **Carry over gitignored local env files.** \`git worktree add\` only populates version-controlled files, so a fresh worktree has NO \`.env\` files and the app can't boot — this silently blocks later verification. Copy the base checkout's ignored env files into the worktree, preserving relative paths:
-   - List ignored files: \`git -C ${REPO} ls-files --others --ignored --exclude-standard\`.
-   - Keep ONLY env files — basename matching \`.env\` or \`.env.*\` (e.g. \`.env\`, \`.env.local\`, \`.env.development\`). Filter with \`grep -E '(^|/)\\.env(\\.[^/]+)?$'\`. Do NOT copy node_modules/dist/build/cache artifacts.
-   - For each match \`<rel>\`: \`mkdir -p "<worktreePath>/$(dirname <rel>)"\` then \`cp "${REPO}/<rel>" "<worktreePath>/<rel>"\`. They stay gitignored in the worktree — confirm none show up in \`git -C <worktreePath> status\`.
-   - Record the copied relative paths in \`envFilesCopied\` (empty array if the repo has none — that's fine).
-7. **Warm the worktree's dependencies** so later stages (Implement/Simplify/Review/Verify) can run typecheck/lint/tests. A fresh worktree has NO \`node_modules\`. Set \`depsWarmed\` to which path you took. (This step is JS/Node-flavored; adapt to the repo's ecosystem — for non-Node repos, set depsWarmed='none' and let later stages set up the environment on demand.)
-   - If \`${REPO}/node_modules\` does NOT exist, set depsWarmed='none' and skip (nothing to warm; later stages install on demand).
-   - **FAST PATH (clone) — prefer this.** Valid ONLY when BOTH: (a) the base checkout is APFS (macOS) — just attempt the clone and fall back on error; AND (b) the worktree's lockfile matches the base's: \`diff -q "${REPO}/pnpm-lock.yaml" "<worktreePath>/pnpm-lock.yaml"\` identical (use whichever lockfile exists: pnpm-lock.yaml / package-lock.json / yarn.lock; if none, skip clone). When valid: enumerate top-level node_modules dirs via \`cd ${REPO} && find . -type d -name node_modules -prune | grep -v '/node_modules/'\` (root + each workspace package; NOT nested .pnpm ones). For EACH \`<rel>\`: \`mkdir -p "<worktreePath>/$(dirname <rel>)"\` then \`cp -c -R "${REPO}/<rel>" "<worktreePath>/<rel>"\` (\`-c\` = APFS clonefile, copy-on-write, near-instant, no extra disk; pnpm uses RELATIVE symlinks so the clone resolves at the new path). If \`cp -c\` errors (not APFS/cross-volume), abandon clone → fallback. On success set depsWarmed='clone'.
-   - **FALLBACK (install).** If clone isn't valid/failed but base had node_modules: \`cd <worktreePath> && pnpm install --prefer-offline\` (or npm ci / yarn matching the lockfile — global store is warm so it's link-mostly). Set depsWarmed='install'. If install would be too heavy to be worth it, instead set depsWarmed='skipped' and note later stages should install on demand.
-   - These node_modules stay gitignored — confirm \`git -C <worktreePath> status\` is still clean afterward.
-8. Check whether the repo ships its own PR skill: test for the file \`<worktreePath>/.claude/skills/pr/SKILL.md\`. Set hasPrSkill=true if it exists, else false.
+步骤:
+1. cd ${REPO}。运行 \`git fetch origin --prune\`（离线则忽略失败）。确定最新的基线 ref：若 \`origin/${BASE}\` 存在则优先用它，否则用本地 \`${BASE}\`。
+2. 选定功能分支名（给了就用，否则派生如 feat/<slug> 或 fix/<slug>）。确认它不存在（需要时加 -2 等）。
+3. 在主检出之外选一个 worktree 路径：同级目录如 \`<repo>-worktrees/<branch-slug>\`（需要时创建父目录）。避免嵌套在仓库内。
+4. 创建它: \`git -C ${REPO} worktree add <worktreePath> -b <branch> <baseRef>\`。
+5. 验证: worktree 路径存在、\`git -C <worktreePath> rev-parse --abbrev-ref HEAD\` 显示新分支、\`git -C <worktreePath> status\` 是干净的。
+6. **携带 gitignored 的本地 env 文件。** \`git worktree add\` 只填充版本控制下的文件，所以全新 worktree 没有 \`.env\` 文件、应用起不来 —— 这会默默阻塞后续验证。把基检出的 ignored env 文件复制进 worktree，保留相对路径：
+   - 列出 ignored 文件: \`git -C ${REPO} ls-files --others --ignored --exclude-standard\`。
+   - 只保留 env 文件 —— basename 匹配 \`.env\` 或 \`.env.*\`（例如 \`.env\`、\`.env.local\`、\`.env.development\`）。用 \`grep -E '(^|/)\\.env(\\.[^/]+)?$'\` 过滤。不要复制 node_modules/dist/build/cache 产物。
+   - 对每个匹配 \`<rel>\`: \`mkdir -p "<worktreePath>/$(dirname <rel>)"\` 然后 \`cp "${REPO}/<rel>" "<worktreePath>/<rel>"\`。它们在 worktree 里仍是 gitignored —— 确认没有出现在 \`git -C <worktreePath> status\` 里。
+   - 把复制的相对路径记入 \`envFilesCopied\`（仓库没有则为空数组 —— 没关系）。
+7. **预热 worktree 的依赖**，让后续阶段（Implement/Simplify/Review/Verify）能跑 typecheck/lint/tests。全新 worktree 没有 \`node_modules\`。把 \`depsWarmed\` 设为你走的路径。（此步偏 JS/Node；按仓库生态适配 —— 非 Node 仓库则设 depsWarmed='none'，让后续阶段按需准备环境。）
+   - 若 \`${REPO}/node_modules\` 不存在，设 depsWarmed='none' 并跳过（没东西可预热；后续阶段按需安装）。
+   - **快路径（clone）—— 优先。** 仅当同时满足才有效：(a) 基检出是 APFS（macOS）—— 直接尝试 clone，出错则回退；且 (b) worktree 的 lockfile 与基线一致: \`diff -q "${REPO}/pnpm-lock.yaml" "<worktreePath>/pnpm-lock.yaml"\` 相同（用存在的那个 lockfile：pnpm-lock.yaml / package-lock.json / yarn.lock；都没有则跳过 clone）。有效时：通过 \`cd ${REPO} && find . -type d -name node_modules -prune | grep -v '/node_modules/'\` 枚举顶层 node_modules 目录（根 + 每个 workspace package；不含嵌套的 .pnpm）。对每个 \`<rel>\`: \`mkdir -p "<worktreePath>/$(dirname <rel>)"\` 然后 \`cp -c -R "${REPO}/<rel>" "<worktreePath>/<rel>"\`（\`-c\` = APFS clonefile，写时复制，近乎瞬时、无额外磁盘；pnpm 用相对 symlink，所以 clone 在新路径下可解析）。若 \`cp -c\` 报错（非 APFS/跨卷），放弃 clone → 回退。成功则设 depsWarmed='clone'。
+   - **回退（install）。** 若 clone 不可行/失败但基检出有 node_modules: \`cd <worktreePath> && pnpm install --prefer-offline\`（或匹配 lockfile 的 npm ci / yarn —— 全局 store 已暖，所以基本是 link）。设 depsWarmed='install'。若 install 太重不值得，则设 depsWarmed='skipped' 并注明后续阶段按需安装。
+   - 这些 node_modules 保持 gitignored —— 确认之后 \`git -C <worktreePath> status\` 仍干净。
+8. 检查仓库是否自带 PR skill: 测试文件 \`<worktreePath>/.claude/skills/pr/SKILL.md\` 是否存在。存在则 hasPrSkill=true，否则 false。
 
-Do NOT implement the task. Do NOT modify the user's original checkout (only READ from it for the env copy + node_modules clone). Return the worktree path, branch, the base ref you branched from, hasPrSkill, envFilesCopied, and depsWarmed.`,
+不要实现任务。不要修改用户的原始检出（仅从它读取以复制 env + clone node_modules）。返回 worktree 路径、分支、你分支出来的基线 ref、hasPrSkill、envFilesCopied、depsWarmed。`,
   { phase: 'Setup', schema: SETUP_SCHEMA }
 )
 
 if (!setup || !setup.worktreePath) {
-  log('Setup failed to create a worktree — aborting.')
+  log('Setup 未能创建 worktree —— 中止。')
   return { setup, aborted: true }
 }
 const WT = setup.worktreePath
 const BRANCH = setup.branch
-log(`Worktree ready: ${WT} (branch ${BRANCH} off ${setup.baseRef})`)
+log(`Worktree 就绪: ${WT}（分支 ${BRANCH}，基于 ${setup.baseRef}）`)
 const envCopied = setup.envFilesCopied || []
 log(
   envCopied.length
-    ? `Carried ${envCopied.length} gitignored env file(s) into the worktree: ${envCopied.join(', ')}`
-    : 'No gitignored env files to carry over (or repo has none).'
+    ? `已携带 ${envCopied.length} 个 gitignored env 文件进 worktree: ${envCopied.join(', ')}`
+    : '没有需要携带的 gitignored env 文件（或仓库没有）。'
 )
 const depsWarmed = setup.depsWarmed || 'none'
 log(
   {
-    clone: 'Dependencies warmed via APFS clone (node_modules copy-on-write from base checkout) — typecheck/tests runnable.',
-    install: 'Dependencies warmed via package-manager install in the worktree — typecheck/tests runnable.',
-    skipped: 'Dependency warm-up skipped — later stages install on demand before typecheck/tests.',
-    none: 'No dependencies to warm (base checkout has no node_modules / non-Node repo).',
-  }[depsWarmed] || `Dependency warm-up: ${depsWarmed}.`
+    clone: '依赖已通过 APFS clone 预热（node_modules 从基检出写时复制）—— typecheck/tests 可运行。',
+    install: '依赖已通过在 worktree 内包管理器 install 预热 —— typecheck/tests 可运行。',
+    skipped: '依赖预热已跳过 —— 后续阶段在 typecheck/tests 前按需安装。',
+    none: '无可预热的依赖（基检出无 node_modules / 非 Node 仓库）。',
+  }[depsWarmed] || `依赖预热: ${depsWarmed}.`
 )
 
-// All later phases operate inside the worktree (WT), never the original ${REPO} checkout.
+// 所有后续阶段都在 worktree（WT）内进行，绝不在原始 ${REPO} 检出内。
 
 // ───────────────────────── Phase 1: Implement ─────────────────────────
 phase('Implement')
@@ -116,26 +116,26 @@ const IMPL_SCHEMA = {
   },
 }
 const impl = await agent(
-  `Implement the following task. Work ONLY inside the worktree at ${WT} (branch ${BRANCH}). Do NOT touch any other checkout. Do NOT git commit — a later stage commits once.
+  `实现以下任务。只在 worktree ${WT}（分支 ${BRANCH}）内工作。不要碰任何其他检出。不要 git commit —— 后续阶段会统一提交一次。
 
 TASK:
 """
 ${TASK}
 """
 
-Approach:
-- Investigate first: read the relevant code, types, and call sites in ${WT} before editing. Confirm signatures/field names against the actual source — don't assume.
-- Make the change focused and idiomatic — match the surrounding code's conventions, naming, and comment density.
-- Prefer putting new pure/testable logic in its own module (free of framework/runtime-specific imports) and wiring it in, so it can be unit-tested in isolation.
-- Add or update tests for the new behavior where the repo has a test setup.
-- Respect any scope / out-of-scope boundaries stated in the task. Do not gold-plate. Leave a brief code comment for any deliberately deferred follow-up.
-- Sanity-check types/build on the changed area if it's fast (don't block on a slow full build).
-- Dependencies were pre-warmed in Setup (depsWarmed=${depsWarmed}), so they should already be present — typecheck/tests are runnable without installing. If you ADD or CHANGE a dependency, run the repo's install yourself; the global package store is warm so it's fast. If depsWarmed is 'skipped'/'none' and you need to typecheck/test, set up the environment first.
+方法:
+- 先调研：编辑前先读 ${WT} 里相关代码、类型和调用点。对照实际源码确认签名/字段名 —— 不要假设。
+- 变更聚焦且地道 —— 匹配周围代码的约定、命名和注释密度。
+- 优先把新的纯/可测逻辑放进它自己的模块（不含框架/运行时特定 import）再接线进去，以便单独单测。
+- 在仓库有测试设置的地方为新行为添加或更新测试。
+- 尊重任务里声明的任何范围 / 超出范围边界。不要镀金。对任何刻意延后的后续项留一段简短代码注释。
+- 改动区域若 type-check/build 很快，做一次健全性检查（不要被慢的全量 build 阻塞）。
+- 依赖已在 Setup 阶段预热（depsWarmed=${depsWarmed}），所以应已就位 —— 无需安装即可跑 typecheck/tests。如果你新增或改动了依赖，自己跑仓库的 install；全局包 store 已暖，所以很快。若 depsWarmed 为 'skipped'/'none' 且你需要 typecheck/test，先准备环境。
 
-Return: files changed, a concise summary, key decisions, and any open concerns for downstream review.`,
+返回：改动的文件、简明摘要、关键决策、以及给下游 review 的任何开放疑虑。`,
   { phase: 'Implement', schema: IMPL_SCHEMA }
 )
-log(`Implement: ${impl?.filesChanged?.length ?? 0} file(s) changed`)
+log(`Implement: 改动 ${impl?.filesChanged?.length ?? 0} 个文件`)
 
 // ───────────────────────── Phase 2: Simplify ─────────────────────────
 phase('Simplify')
@@ -148,19 +148,19 @@ const SIMP_SCHEMA = {
   },
 }
 const simp = await agent(
-  `Quality pass — SIMPLIFY ONLY (do not hunt for bugs, do not change behavior, do not expand scope) — over the uncommitted changes in the worktree ${WT} (branch ${BRANCH}).
+  `质量 pass —— 只做简化（不要找 bug、不要改行为、不要扩范围）—— 针对 worktree ${WT}（分支 ${BRANCH}）中未提交的改动。
 
-What was just implemented:
+刚实现的内容:
 ${JSON.stringify(impl, null, 2)}
 
-Run \`cd ${WT} && git --no-pager diff\` to see the exact changes, then improve ONLY the changed code for: reuse/dedup, simplification & readability, efficiency, and correct altitude (logic in the right module; entrypoints stay thin). Keep behavior identical. Do not commit. Apply edits directly and return what you changed.`,
+运行 \`cd ${WT} && git --no-pager diff\` 查看精确改动，然后只针对改动代码改进：复用/去重、简化与可读性、效率、以及正确的层次（逻辑在合适的模块；入口保持精简）。保持行为一致。不要提交。直接应用编辑并返回你改了什么。`,
   { phase: 'Simplify', schema: SIMP_SCHEMA }
 )
-log(`Simplify: ${simp?.changesMade?.length ?? 0} cleanup(s)`)
+log(`Simplify: ${simp?.changesMade?.length ?? 0} 项清理`)
 
 // ───────────────────────── Phase 3: Review + Fix ─────────────────────────
-// Uses Codex for an independent second opinion when available; otherwise the agent
-// does a rigorous blocking-issue review itself. Either way it fixes what it confirms.
+// 可用时用 Codex 取独立第二意见；否则 agent 自己做严格的阻塞问题
+// review。无论哪种，它都修掉自己确认的问题。
 let review = null
 if (RUN_REVIEW) {
   phase('Review')
@@ -186,31 +186,31 @@ if (RUN_REVIEW) {
     },
   }
   review = await agent(
-    `Review the uncommitted diff in the worktree ${WT} (branch ${BRANCH}) for BLOCKING issues only, then fix them.
+    `Review worktree ${WT}（分支 ${BRANCH}）中未提交 diff 的阻塞性问题，然后修复它们。
 
-Steps:
-1. \`cd ${WT} && git --no-pager diff\` to capture the change set.
-2. Review the diff for BLOCKING problems — things that would break production or fail review: correctness bugs, runtime/environment incompatibilities, security holes (injection/escaping/authz), regressions to existing behavior, pathological regex/perf, and type errors. Ignore pure style nits (Simplify already ran).
-   - If a Codex CLI/MCP is available and authenticated, run it on the diff for an independent second opinion and fold its findings in. Set usedCodex=true.
-   - If Codex is unavailable/unauthenticated, do the review yourself — just as rigorously. Set usedCodex=false.
-3. FIX every blocking issue you can confirm is real (edit files directly in ${WT}). Do NOT commit. Do NOT expand scope.
+步骤:
+1. \`cd ${WT} && git --no-pager diff\` 捕获变更集。
+2. Review diff 找阻塞性问题 —— 会搞坏生产或过不了 review 的东西：正确性 bug、运行时/环境不兼容、安全漏洞（注入/转义/authz）、对现有行为的回归、病态正则/性能、以及类型错误。忽略纯风格细枝末节（Simplify 已跑过）。
+   - 如果有可用且已认证的 Codex CLI/MCP，在 diff 上跑它取独立第二意见并合并其发现。设 usedCodex=true。
+   - 如果 Codex 不可用/未认证，你自己做 review —— 同样严格。设 usedCodex=false。
+3. 修掉每一个你能确认为真的阻塞问题（直接在 ${WT} 里编辑文件）。不要提交。不要扩范围。
 
-Return the structured result (usedCodex, the blocking issues with whether each was fixed, the fixes applied, and a one-line verdict).`,
+返回结构化结果（usedCodex、每个阻塞问题及其是否已修、应用的修复、以及一行结论）。`,
     { phase: 'Review', schema: REVIEW_SCHEMA }
   )
   log(
-    `Review: usedCodex=${review?.usedCodex}, ${review?.blockingIssues?.length ?? 0} blocking issue(s)`
+    `Review: usedCodex=${review?.usedCodex}，${review?.blockingIssues?.length ?? 0} 个阻塞问题`
   )
 } else {
-  log('Review skipped (runReview=false).')
+  log('Review 已跳过（runReview=false）。')
 }
 
-// Delegate the verify+ship flow to the target repo's own /pr skill when it has one.
-// That skill runs its own (heavier, app-driving) verification + regression sweep and
-// only opens a PR once the feature is proven — so we skip this workflow's Verify phase.
+// 当目标仓库自带 /pr skill 时，把验证+交付流程委派给它。
+// 该 skill 跑它自己更重的（驱动应用的）验证 + 回归扫描，并
+// 仅在功能被证明后开 PR —— 因此跳过本 workflow 的 Verify 阶段。
 const USE_PR_SKILL = OPEN_PR && !!setup.hasPrSkill
 if (USE_PR_SKILL) {
-  log('Found a /pr skill in the worktree — delegating verification + PR to it (skipping this workflow\'s own Verify phase).')
+  log('在 worktree 中发现 /pr skill —— 把验证 + PR 委派给它（跳过本 workflow 自己的 Verify 阶段）。')
 }
 
 // ───────────────────────── Phase 4: Verify ─────────────────────────
@@ -238,24 +238,24 @@ if (!USE_PR_SKILL) {
     },
   }
   verify = await agent(
-    `Locally verify the uncommitted changes in the worktree ${WT} (branch ${BRANCH}). Be rigorous and HONEST — report real command output; never claim success you didn't observe.
+    `本地验证 worktree ${WT}（分支 ${BRANCH}）中未提交的改动。要严格且诚实 —— 报告真实命令输出；绝不声称你没观察到的成功。
 
-${VERIFY_HINTS ? `Verification hints from the requester: ${VERIFY_HINTS}\n` : ''}Steps:
-1. Discover the right commands from the repo (package.json/turbo.json/Makefile/etc.). Prefer SCOPED, fast checks over full builds: type-check, lint on changed files, and the unit/integration tests that cover the changed code.
-2. Run them; capture pass/fail + key output for each.
-3. If something fails due to a real defect in the new code, apply a MINIMAL fix and re-run (a few iterations max). Do not expand scope. Do not commit.
-4. Honestly list under couldNotVerify anything that can't be checked locally (e.g. real production runtime, external services, manual UX).
+${VERIFY_HINTS ? `来自请求者的验证提示: ${VERIFY_HINTS}\n` : ''}步骤:
+1. 从仓库发现正确命令（package.json/turbo.json/Makefile 等）。优先 SCOPED、快速的检查而非全量 build：type-check、改动文件的 lint、以及覆盖改动代码的单元/集成测试。
+2. 跑它们；捕获每个的通过/失败 + 关键输出。
+3. 如果因新代码的真实缺陷而失败，应用最小修复并重跑（最多几轮）。不要扩范围。不要提交。
+4. 诚实列出不能在本地检查的东西（如真实生产运行时、外部服务、手动 UX），放入 couldNotVerify。
 
-Set passed=true ONLY if the relevant checks for the changed code pass. Return the actual commands you ran.`,
+只有当改动代码的相关检查通过时才设 passed=true。返回你实际跑过的命令。`,
     { phase: 'Verify', schema: VERIFY_SCHEMA }
   )
   log(`Verify: passed=${verify?.passed}`)
 }
 
 // ───────────────────────── Phase 5: PR ─────────────────────────
-// Delegated path (USE_PR_SKILL): commit, then hand off to the repo's /pr skill, which
-// verifies the feature and runs the regression sweep before it opens the PR.
-// Inline path: open the PR only after this workflow's own Verify passed.
+// 委派路径（USE_PR_SKILL）：提交，然后交给仓库的 /pr skill，它在
+// 开 PR 之前验证功能并跑回归扫描。
+// 内联路径：仅在本 workflow 自己的 Verify 通过后开 PR。
 const PR_SCHEMA = {
   type: 'object',
   required: ['prUrl', 'branch', 'summary'],
@@ -268,43 +268,43 @@ const PR_SCHEMA = {
 }
 let pr = null
 if (!OPEN_PR) {
-  log(`openPr=false — stopping after verify. Changes are in the worktree ${WT} (branch ${BRANCH}), uncommitted.`)
+  log(`openPr=false —— 在 verify 后停下。改动在 worktree ${WT}（分支 ${BRANCH}）内，未提交。`)
 } else if (USE_PR_SKILL) {
   phase('PR')
   pr = await agent(
-    `Commit the change, then run THIS repo's own /pr skill to verify-and-ship. Work in the worktree ${WT} (branch ${BRANCH}, base ${BASE}).
+    `提交变更，然后运行本仓库自带的 /pr skill 来验证并交付。在 worktree ${WT}（分支 ${BRANCH}，基线 ${BASE}）内工作。
 
-The /pr skill requires the change to be committed on a branch first, and it independently verifies the feature (a verifier sub-agent drives the running app) and runs the regression sweep BEFORE opening a PR. Do NOT open a PR yourself ahead of that — let the skill gate it.
+/pr skill 要求变更先提交到一个分支上，然后它独立验证功能（一个 verifier 子 agent 驱动运行中的应用）并在开 PR 之前跑回归扫描。不要抢在它之前自己开 PR —— 让 skill 把关。
 
-Steps:
-1. cd ${WT}; review \`git status\` and \`git --no-pager diff\` so the commit includes only the intended files (no stray/unrelated files).
-2. git add the intended files; commit with a clear Conventional Commit message that summarizes the change and notes any deliberate follow-ups/out-of-scope items.
-3. Read \`${WT}/.claude/skills/pr/SKILL.md\` and follow its procedure EXACTLY (bring up the stack, delegate feature verification, regression sweep, then open the PR with proof). Run everything from inside ${WT}.${VERIFY_HINTS ? `\n   Verification hints from the requester to feed the verifier: ${VERIFY_HINTS}` : ''}
-4. Return the PR URL, branch, and short commit sha.
+步骤:
+1. cd ${WT}；查看 \`git status\` 和 \`git --no-pager diff\`，确保提交只含目标文件（无杂散/无关文件）。
+2. git add 目标文件；用清晰的约定式提交信息提交，概述变更并注明任何刻意的后续项/超出范围项。
+3. 读 \`${WT}/.claude/skills/pr/SKILL.md\` 并严格按其流程执行（起栈、委派功能验证、回归扫描、然后带证据开 PR）。全部在 ${WT} 内运行。${VERIFY_HINTS ? `\n   给 verifier 的、来自请求者的验证提示: ${VERIFY_HINTS}` : ''}
+4. 返回 PR URL、分支、以及短 commit sha。
 
-If the skill's verification does not pass within its retry cap, or git push / gh fails (auth/permissions), do NOT force anything — return prUrl='' with the verdict/failure reason in summary so the human can finish it.`,
+如果 skill 的验证在其重试上限内未通过，或 git push / gh 失败（认证/权限），不要强推 —— 返回 prUrl='' 并在 summary 里写明结论/失败原因，让人类来收尾。`,
     { phase: 'PR', schema: PR_SCHEMA }
   )
-  log(pr?.prUrl ? `PR opened: ${pr.prUrl}` : `PR not opened: ${pr?.summary ?? 'unknown'}`)
+  log(pr?.prUrl ? `PR 已开: ${pr.prUrl}` : `PR 未开: ${pr?.summary ?? '未知'}`)
 } else if (verify && verify.passed) {
   phase('PR')
   pr = await agent(
-    `Commit the verified changes and open a PR. Work in the worktree ${WT} (branch ${BRANCH}, base ${BASE}).
+    `提交已验证的改动并开 PR。在 worktree ${WT}（分支 ${BRANCH}，基线 ${BASE}）内工作。
 
-Steps:
-1. cd ${WT}; review \`git status\` and \`git --no-pager diff\` so the commit includes only the intended files (no stray/unrelated files).
-2. git add the intended files; commit with a clear Conventional Commit message that summarizes the change and notes any deliberate follow-ups/out-of-scope items.
-3. git push -u origin ${BRANCH}.
-4. Open the PR: \`gh pr create --base ${BASE} --head ${BRANCH}\` with a clear title and a body covering: what & why, the verification performed, and explicit out-of-scope/follow-ups.
-5. Return the PR URL, branch, and short commit sha.
+步骤:
+1. cd ${WT}；查看 \`git status\` 和 \`git --no-pager diff\`，确保提交只含目标文件（无杂散/无关文件）。
+2. git add 目标文件；用清晰的约定式提交信息提交，概述变更并注明任何刻意的后续项/超出范围项。
+3. git push -u origin ${BRANCH}。
+4. 开 PR: \`gh pr create --base ${BASE} --head ${BRANCH}\`，带清晰标题和正文，覆盖：做了什么及为什么、执行的验证、以及明确的超出范围/后续项。
+5. 返回 PR URL、分支、以及短 commit sha。
 
-If git push or gh fails (auth/permissions), do NOT force anything — return prUrl='' with the failure reason in summary so the human can finish it.`,
+如果 git push 或 gh 失败（认证/权限），不要强推 —— 返回 prUrl='' 并在 summary 里写明失败原因，让人类来收尾。`,
     { phase: 'PR', schema: PR_SCHEMA }
   )
-  log(pr?.prUrl ? `PR opened: ${pr.prUrl}` : `PR not opened: ${pr?.summary ?? 'unknown'}`)
+  log(pr?.prUrl ? `PR 已开: ${pr.prUrl}` : `PR 未开: ${pr?.summary ?? '未知'}`)
 } else {
   log(
-    `Verification did NOT pass — skipping commit/PR. Changes remain in the worktree ${WT} (branch ${BRANCH}) for human review.`
+    `验证未通过 —— 跳过提交/PR。改动留在 worktree ${WT}（分支 ${BRANCH}）供人类 review。`
   )
 }
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,141 +1,139 @@
 ---
-title: Knowledge-base architecture
+title: 知识库架构
 type: decision
 status: adopted
 ---
 
-# Knowledge-base architecture
+# 知识库架构
 
-How this repo is organized as the operating substrate for a long-lived, autonomous agent
-(and its humans). Everything is plain **markdown + frontmatter in git** — diffable, reviewable,
-agent-writable. This doc is the durable record of the model and the options rejected, so the
-shape stays intentional as it grows.
+本仓库如何组织成一个长期运行、自主的 agent（及其背后人类）的运行底座。一切都是
+git 中普通的 **markdown + frontmatter** —— 可 diff、可 review、agent 可写。这份文档是
+该模型及被否决方案的持久记录，让它的形态在成长过程中保持有意为之。
 
 ---
 
-## The model (v1 — deliberately minimal)
+## 模型（v1 —— 刻意保持最小化）
 
-Two ideas only:
+只有两个想法：
 
-1. **Artifacts** are global, foldered by **kind**; `domain:` is a **field (a list)**, not a folder.
-   Each artifact has exactly one home (by *what it is*). Cross-cutting is handled by tags + links
-   — never by duplicating or by nesting inside a domain.
-2. **Domains** are "loops" — a thread of work with a charter, cadence, and metrics. A domain
-   folder holds only its **README (charter)** + **machinery** (metrics, collectors). It **links**
-   artifacts; it never contains them.
+1. **Artifact** 是全局的，按**类别（kind）**分文件夹；`domain:` 是一个**字段（列表）**，不是文件夹。
+   每个 artifact 恰好有一个家（按*它是什么*归类）。跨切面用 tag + 链接处理
+   —— 绝不靠复制，也绝不靠嵌套进某个 domain。
+2. **Domain** 即"循环" —— 一段有章程、节奏和指标的工作。一个 domain
+   文件夹只持有它的 **README（章程）** + **机器（machinery）**（指标、采集器）。它**链接**
+   artifact；它从不包含它们。
 
-### Kinds (start with just these two)
+### 类别（先从这两个开始）
 
-| kind | what it is | folder | key frontmatter |
+| kind | 是什么 | 文件夹 | 关键 frontmatter |
 |---|---|---|---|
-| `signal` | evidence: feedback / idea / observation (deduped, frequency-counted) | `signals/` | `category, frequency, sources[], domain[], status` |
-| `doc` | durable knowledge: an analysis, a decision, a thing you learned | `docs/` | `domain[], status?, links` |
+| `signal` | 证据：反馈 / 想法 / 观察（去重、按频次计数） | `signals/` | `category, frequency, sources[], domain[], status` |
+| `doc` | 持久知识：一份分析、一个决策、一件学到的事 | `docs/` | `domain[], status?, links` |
 
-That's enough to run almost any loop. Each folder's `README` is its schema — read it before
-adding artifacts of that kind. Committed work doesn't need its own kind to start: a loop's
-to-dos live inline as a backlog in its domain `README`. Promote them to a `task` kind only
-once you've earned it (below).
+这就足够运行几乎任何循环。每个文件夹的 `README` 是它的 schema —— 在添加该类别的
+artifact 之前先读它。已承诺的工作一开始不需要自己的类别：一个循环的待办以内联
+backlog 的形式活在它的 domain `README` 里。只有当你挣到它时（见下），才把它们升级
+为 `task` 类别。
 
-### Earning a new kind
+### 挣得一个新类别
 
-Default to an existing kind. Add a new one **only** when it has all three of: its own status
-machine **and** queryable frontmatter fields **and** a distinct body shape. Otherwise it's a
-`doc` or a `signal` with a tag, or a backlog line in a domain README. Examples of kinds teams
-have earned once volume justified them:
+默认用已有的类别。**只有**当同时满足这三点时才新增：它有自己的状态机**且**可查询的
+frontmatter 字段**且**独特的正文形态。否则它就是一个带 tag 的 `doc` 或 `signal`，或者
+domain README 里的一行 backlog。以下是各团队在量级达到时挣得的类别示例：
 
-- `task` — committed work as its own files, once your backlogs outgrow the domain README (an
-  **experiment** = a task with a `metric`): `status, domain[], metric?, refs`.
-- `ticket` — a support conversation (synced from a helpdesk): `user_email, url, status`.
-- `content` — an outbound draft with a publish lifecycle: `type, status, channel, posted_url, outcome`.
-- entity kinds (`lead`, `keyword`, `campaign`) — when an outreach/ads/SEO loop needs to track many of one thing.
+- `task` —— 已承诺的工作作为独立文件，一旦你的 backlog 超出 domain README（一个
+  **实验** = 一个带 `metric` 的 task）：`status, domain[], metric?, refs`。
+- `ticket` —— 一次客服对话（从 helpdesk 同步）：`user_email, url, status`。
+- `content` —— 一篇带发布生命周期的外发草稿：`type, status, channel, posted_url, outcome`。
+- 实体类别（`lead`、`keyword`、`campaign`）—— 当一个外联/广告/SEO 循环需要追踪某一种东西的多个实例时。
 
-If you can't name the distinct status machine, you haven't earned the kind yet.
+如果你说不出它独特的状态机，你就还没挣到这个类别。
 
-### Domains (loops)
+### Domain（循环）
 
-A domain is one loop: a separable workstream with its own cadence/owner. Spin up a new domain
-only when that's true — otherwise just add a `domain:` tag to an existing one. A domain's
-`README` is its live state: goal/charter, current focus, a backlog of links, links to evidence,
-optional metrics, and a `## Timeline`. It **points at** artifacts; it never holds them.
+一个 domain 就是一个循环：一个有自己节奏/负责人的独立工作流。只有当这一点成立时
+才启动新 domain —— 否则只给已有的打 `domain:` 标签。一个 domain 的
+`README` 是它的实时状态：目标/章程、当前重点、一个链接 backlog、指向证据的链接、
+可选指标，以及一个 `## Timeline`。它**指向** artifact；它从不持有它们。
 
-### Body convention — two layers
+### 正文约定 —— 两层
 
-Each artifact = a normal **main body** + an optional appended **`## Timeline`** (append-only,
-dated: `YYYY-MM-DD | source — what happened`). *"What's true now"* = body; *"what happened"* =
-Timeline. This gives every artifact its own history, absorbs daily logs, and lets a `signal`
-accumulate evidence (frequency = Timeline entries). Git holds the mechanical diff history.
+每个 artifact = 一段正常的**正文** + 一个可选追加的**`## Timeline`**（只追加、
+带日期：`YYYY-MM-DD | 来源 —— 发生了什么`）。*"现在什么是真的"* = 正文；*"发生了什么"* =
+Timeline。这给每个 artifact 自己的历史，吸收日常日志，并让一个 `signal`
+累积证据（frequency = Timeline 条目数）。Git 持有机械的 diff 历史。
 
-### Logs & data
+### 日志与数据
 
-- **`LOG.md`** (root) — global activity feed: one line per ship/ingest. Detail lives in each
-  artifact's `## Timeline`. Append one entry right before the commit that ships a bulk of work.
-- **No separate `daily`/`journal` kind.** A domain's run-log is its `README`'s `## Timeline`
-  (one terse dated line per run); rich per-item detail lives in the items it links. So there are
-  exactly two log surfaces: per-artifact `## Timeline` + the global `LOG.md`.
-- **`domains/<x>/metrics/*.jsonl`** — numeric time-series, written by **deterministic collectors**
-  (code/skills, *not* the LLM). Agents read & interpret. Scorecards are generated from these.
+- **`LOG.md`**（根）—— 全局活动信息流：每次交付/摄入一行。细节活在每个
+  artifact 的 `## Timeline` 里。在交付一批工作的 commit 之前追加一条。
+- **没有单独的 `daily`/`journal` 类别。** 一个 domain 的运行日志是它 `README` 的
+  `## Timeline`（每次运行一行简短带日期的记录）；丰富的逐项细节活在它链接的那些
+  item 里。所以恰好有两个日志面：每个 artifact 的 `## Timeline` + 全局 `LOG.md`。
+- **`domains/<x>/metrics/*.jsonl`** —— 数值时间序列，由**确定性采集器**
+  （代码/skill，*不是* LLM）写入。Agent 读取并解读。记分卡由这些生成。
 
-### Rules (DRY + MECE)
+### 规则（DRY + MECE）
 
-1. **One concept = one home** (by kind). Everyone else links via `[[slug]]`.
-2. **`domain:` is a field (list), not a folder.** Cross-cutting = multi-tag + multi-link.
-3. **Collectors write data; agents write knowledge.** Don't pay an LLM to fetch numbers.
-4. **Frontmatter = anything you'd query.** Prose for everything else.
+1. **一个概念 = 一个家**（按类别）。其他人通过 `[[slug]]` 链接。
+2. **`domain:` 是字段（列表），不是文件夹。** 跨切面 = 多 tag + 多链接。
+3. **采集器写数据；agent 写知识。** 别花钱让 LLM 去取数字。
+4. **Frontmatter = 任何你会去查询的东西。** 其他都用散文。
 
 ---
 
-## Deferred — add only when the need is real (do NOT pre-build)
+## 暂缓 —— 仅当需求真实时才添加（不要预先搭建）
 
-| Later | Trigger to add it |
+| 之后再加 | 触发添加的条件 |
 |---|---|
-| `trigger:` field (cron / webhook / event) | first non-manual automation (e.g. a server-down webhook) |
-| recursive `thread` + `parent:` relation | a domain needs sub-threads (e.g. strategy → tasks) |
-| entity kinds (`lead`, `keyword`, `campaign`) | the outreach / ads / social loops ship |
-| derived index (sqlite / vector) | retrieval volume outgrows ripgrep (~10⁴⁺ artifacts) |
-| reconcile / consolidation daemon | autonomous volume creates dupes / contradictions |
-| autonomy / guardrails / budget formalization | agents act without human review |
+| `trigger:` 字段（cron / webhook / event） | 第一次非手动自动化（例如服务宕机的 webhook） |
+| 递归 `thread` + `parent:` 关系 | 一个 domain 需要子线程（例如战略 → 任务） |
+| 实体类别（`lead`、`keyword`、`campaign`） | 外联 / 广告 / 社交循环交付时 |
+| 派生索引（sqlite / 向量） | 检索量超出 ripgrep 的承受（约 10⁴⁺ artifact） |
+| 对账 / 合并守护进程 | 自主运行产生的量级造成重复 / 矛盾 |
+| 自主性 / 护栏 / 预算形式化 | agent 在无人 review 下行动时 |
 
-The substrate extends to all of these without a rebuild (markdown stays the system of record;
-you layer a cache/daemon on top).
-
----
-
-## Options considered, and why not
-
-1. **Folder-by-domain** (everything for a loop under its own folder). ❌ Cross-cutting artifacts
-   have no single home — an analysis spanning two loops, or a keyword used by three, can't live
-   in one folder. Forces duplication.
-2. **Folder-by-kind only, no domains.** ❌ Loses the thread-of-work + cadence cohesion;
-   "where's the X loop?" has no home.
-3. **Half-nested** (some kinds global, some under domains). ❌ The asymmetry *is* the bug.
-4. **Pure database** (Notion-style). ❌ for now — we want the data to live in *this* repo
-   (code-adjacent, diffable, reviewable). Forward-compatible: a DB can be derived later.
-5. **Heavy taxonomy (8 kinds upfront).** ❌ Premature; every kind you can't justify causes
-   friction. Start with 3, earn more.
-6. **jsonl/tabular for high-volume artifacts.** ❌ One shape (markdown) is simpler; derive SQL
-   later. jsonl only for genuine numeric time-series (metrics).
-
-## Chosen because
-
-It's the convergence of systems that already solved this: **Monday / Asana / Notion** (items +
-properties + relations + *views*; nesting is data, not folders); **markdown-as-system-of-record**
-knowledge bases (the two-layer page; deterministic collectors; nightly reconcile); the
-**knowledge-work canon** — Matuschak (atomic, concept-oriented, densely-linked notes), PARA
-(projects vs areas; stock vs flow), Teresa Torres (outcome → opportunity → solution → experiment).
-
-DRY, MECE, agent-writable, human-reviewable, and graduates to scale without a rebuild.
+这个底座可以不重建地扩展到以上所有（markdown 始终是事实来源；
+你在其上叠加一层缓存/守护进程）。
 
 ---
 
-## Map (where things live)
+## 考虑过的方案，以及为何不用
 
-| I want to… | Go to |
+1. **按 domain 分文件夹**（一个循环的所有东西放在它自己的文件夹下）。❌ 跨切面 artifact
+   没有单一的家 —— 一份横跨两个循环的分析，或一个被三个循环用到的关键词，无法放进
+   一个文件夹。会迫使复制。
+2. **只按类别分文件夹，没有 domain。** ❌ 丢失了工作主线 + 节奏的凝聚力；
+   "X 循环在哪？"没有家。
+3. **半嵌套**（部分类别全局，部分在 domain 下）。❌ 这种不对称*本身就是* bug。
+4. **纯数据库**（Notion 式）。❌ 暂时不用 —— 我们希望数据活在*这个*仓库里
+   （紧邻代码、可 diff、可 review）。向前兼容：数据库可以之后派生。
+5. **重分类法（预先 8 个类别）。** ❌ 过早；每一个你说不清理由的类别都会带来
+   摩擦。从 3 个开始，再挣更多。
+6. **高量级 artifact 用 jsonl/表格。** ❌ 一种形态（markdown）更简单；SQL
+   之后再派生。jsonl 只用于真正的数值时间序列（指标）。
+
+## 之所以选择
+
+它是若干已经解决了此事的系统的汇合：**Monday / Asana / Notion**（item +
+属性 + 关系 + *视图*；嵌套是数据，不是文件夹）；**以 markdown 为事实来源**的
+知识库（两层页面；确定性采集器；夜间对账）；**知识工作的经典** —— Matuschak
+（原子化、面向概念、密集链接的笔记），PARA（projects vs areas；stock vs flow），
+Teresa Torres（outcome → opportunity → solution → experiment）。
+
+DRY、MECE、agent 可写、人可 review，且无需重建即可演进到规模化。
+
+---
+
+## 地图（东西放在哪）
+
+| 我想… | 去 |
 |---|---|
-| record a fact / insight we learned | `docs/` |
-| capture feedback / an idea (with frequency) | `signals/` |
-| track a piece of committed work | a backlog line in the domain `README` (or `tasks/` once earned) |
-| read a deep analysis | `docs/` |
-| see why we chose something | `docs/` (a decision) |
-| see a loop's goal / cadence / state | `domains/<x>/README.md` |
-| see metrics over time | `domains/<x>/metrics/*.jsonl` + scorecard |
-| spin up a new loop | run the `new-loop` skill |
+| 记录我们学到的一个事实 / 洞见 | `docs/` |
+| 捕获一条反馈 / 一个想法（带频次） | `signals/` |
+| 追踪一项已承诺的工作 | domain `README` 里的一行 backlog（挣到后用 `tasks/`） |
+| 读一份深度分析 | `docs/` |
+| 看我们为什么选了某个方案 | `docs/`（一个 decision） |
+| 看一个循环的目标 / 节奏 / 状态 | `domains/<x>/README.md` |
+| 看指标随时间变化 | `domains/<x>/metrics/*.jsonl` + 记分卡 |
+| 启动一个新循环 | 运行 `new-loop` skill |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,81 +1,80 @@
 <!--
-  This is CLAUDE.md — the context your agent reads on EVERY session. It is the single
-  highest-leverage file in this repo. Replace every {{PLACEHOLDER}}, delete the guidance
-  comments (<!-- ... -->) once you've read them, and cut any section that doesn't apply.
-  Keep it tight: this is a briefing, not a manual. Detail belongs in skills and docs.
+  这是 CLAUDE.md —— 你的 agent 每次会话都会读取的上下文。它是本仓库中
+  杠杆最高的单个文件。替换每一个 {{PLACEHOLDER}}，读完后删掉这些指导性
+  注释（<!-- ... -->），并删掉任何不适用的章节。保持精炼：这是一份简报，
+  不是手册。细节应放在 skills 和 docs 里。
 -->
 
-# {{PRODUCT_NAME}} — Operating Context
+# {{PRODUCT_NAME}} —— 运行上下文
 
-<!-- One line: who the agent is and whose job it's doing. -->
-You are {{AGENT_ROLE, e.g. "head of growth and owner of example.com"}}.
+<!-- 一句话：agent 是谁，在做谁的工作。 -->
+你是 {{AGENT_ROLE, 例如 "增长负责人兼 example.com 的拥有者"}}。
 
-## What it is
-<!-- 2-4 lines. What is the product/business/project? Who uses it? What's the agent's mandate? -->
-**{{PRODUCT_NAME}}** ({{URL}}) — {{ONE_LINE_DESCRIPTION}}.
-- **Users:** {{WHO_USES_IT}}.
-- **Mandate:** {{WHAT_THE_AGENT_IS_HERE_TO_MOVE — e.g. "re-grow signups and recover revenue"}}.
-- {{ANY_KEY_BACKGROUND — founders, history, what's legacy/out of scope}}.
+## 它是什么
+<!-- 2-4 行。产品/业务/项目是什么？谁在用它？agent 的使命是什么？ -->
+**{{PRODUCT_NAME}}**（{{URL}}）—— {{一句话描述}}。
+- **用户：** {{谁在用它}}。
+- **使命：** {{agent 要推动什么 —— 例如 "重新拉动注册增长并恢复营收"}}。
+- {{任何关键背景 —— 创始人、历史、哪些是遗留/不在范围内}}。
 
-## Current state & focus
-<!-- The agent needs to know the situation, not just the product. Numbers if you have them.
-     This is the section to keep freshest — update it as the situation changes. -->
-{{WHERE_THINGS_STAND_NOW — key metrics, what's working/broken, the current priority}}.
-Detail: {{LINK_TO_A_DOC_OR_DELETE}}.
+## 当前状态与重点
+<!-- agent 需要知道现状，而不只是产品。有数字就给数字。
+     这一节要保持最新 —— 随着情况变化及时更新。 -->
+{{当前情况 —— 关键指标、什么在用/什么坏了、当前优先级}}。
+详情：{{某个文档的链接，或删除}}。
 
-## Voice & tone
-<!-- Only if the agent writes anything customer-facing. Delete if not. Be specific:
-     vague tone rules don't survive contact with a draft. -->
-Write like {{A_REAL_PERSON_DESCRIPTION — e.g. "an interesting, proactive friend: warm, human, never a support bot"}}.
-- {{CONCRETE_RULE_1 — e.g. "No em-dashes; they read as AI slop. Use commas/periods."}}
-- {{CONCRETE_RULE_2}}
+## 语气与口吻
+<!-- 仅当 agent 会写面向客户的内容时才保留。不写就删除。要具体：
+     模糊的语气规则活不过一次草稿。 -->
+写得像 {{一个真实的人的描述 —— 例如 "一个有趣、主动的朋友：温暖、有人情味，绝不是客服机器人"}}。
+- {{具体规则 1 —— 例如 "不要用破折号；它读起来像 AI 套话。用逗号/句号。"}}
+- {{具体规则 2}}
 
-## Data & tooling
-<!-- How does the agent get real numbers? List the sources + the skill/CLI/credential for each.
-     Anything requiring a credential should point at a setup skill or an .env, not inline secrets. -->
-- **{{METRICS_SOURCE — e.g. revenue}}:** {{HOW — e.g. "Stripe CLI, default --live for reads"}}. {{[[link-to-setup-skill]]}}
-- **{{PRODUCT_DATA — e.g. app DB}}:** {{HOW — e.g. "read-only Postgres via .env"}}. {{[[link]]}}
-- **{{ANALYTICS}}:** {{HOW}}.
-<!-- Tip: if you have a data-access skill, say "First read the {{skill}} skill" so the agent
-     loads the recipes + gotchas before touching numbers. -->
+## 数据与工具
+<!-- agent 如何拿到真实数字？列出每个来源及其 skill/CLI/凭据。
+     任何需要凭据的，都指向一个 setup skill 或 .env，而不是把密钥写进文件。 -->
+- **{{指标来源 —— 例如 营收}}：** {{如何获取 —— 例如 "Stripe CLI，读取默认 --live"}}。{{[[setup-skill 链接]]}}
+- **{{产品数据 —— 例如 应用 DB}}：** {{如何获取 —— 例如 "通过 .env 的只读 Postgres"}}。{{[[链接]]}}
+- **{{分析}}：** {{如何获取}}。
+<!-- 小贴士：如果你有一个数据访问 skill，就写 "先读 {{skill}} skill"，让 agent
+     在碰数字之前先加载其中的配方和坑点。 -->
 
-## Knowledge base (full model: `ARCHITECTURE.md`)
-<!-- This block is generic — it describes the substrate this kit ships. Keep it; it tells the
-     agent how to file what it learns. Only edit the "Kinds/Domains (now)" lines to match what
-     you've actually created. -->
-**Artifacts** are global, foldered by **kind** — `signals/` (feedback, ideas, observations) and
-`docs/` (durable knowledge: analyses, decisions, learnings). Committed work starts as a backlog
-line in the owning domain's `README`; promote to a `task` kind only once that outgrows the
-README. `domain:` is a frontmatter field (a list), never a folder. **Domains**
-(`domains/*/`) are agent loops whose `README` holds the loop's **state** — goal/context, current
-focus, a `## Timeline`, and **links** to its artifacts (it points to them, never contains them).
-Body = main text + optional append-only `## Timeline`. Each folder's `README` is its schema.
+## 知识库（完整模型见 `ARCHITECTURE.md`）
+<!-- 这一节是通用的 —— 它描述的是这套 kit 所搭载的底层结构。保留它；它告诉
+     agent 如何归档自己学到的东西。只需编辑 "Kinds/Domains (now)" 那两行，
+     使其与你实际创建的内容一致。 -->
+**Artifact** 是全局的，按**类别（kind）**分文件夹 —— `signals/`（反馈、想法、观察）和
+`docs/`（持久知识：分析、决策、经验教训）。已承诺的工作最初作为一行 backlog 写在
+所属 domain 的 `README` 里；只有当它超出 README 时才升级为 `task` 类别。`domain:`
+是一个 frontmatter 字段（一个列表），绝不是文件夹。**Domain**
+（`domains/*/`）是 agent 循环，其 `README` 持有该循环的**状态** —— 目标/背景、当前
+重点、一个 `## Timeline`，以及指向其 artifact 的**链接**（它指向它们，从不包含它们）。
+正文 = 主要文本 + 可选的只追加 `## Timeline`。每个文件夹的 `README` 就是它的 schema。
 
-**Reuse before creating** (earn the structure, don't pre-build):
-- **Kind** — start with just `signal` + `doc`. Add a new kind only if it has its own status
-  machine **and** queryable fields **and** body shape. Otherwise it's a `doc` or a `signal`.
-- **Domain** — default to a `domain:` tag on an existing one; spin up a new domain only when
-  it's a separable workstream with its own cadence/owner (use the `new-loop` skill).
+**先复用再创建**（让结构挣出来，不要预先搭建）：
+- **类别（Kind）** —— 从 `signal` + `doc` 开始。只有当它有自己的状态机**且**可查询字段**且**
+  特定正文形态时，才新增一个类别。否则它就是一个 `doc` 或一个 `signal`。
+- **Domain** —— 默认给已有的打 `domain:` 标签；只有当它是一个有自己节奏/负责人的独立
+  工作流时，才启动一个新 domain（用 `new-loop` skill）。
 
-- **`LOG.md`** — global feed; **append ONE line right before the commit/PR that ships major
-  work** (`## YYYY-MM-DD · title · #tags` + `What:`/`Refs:`). Detail → each artifact's `## Timeline`.
+- **`LOG.md`** —— 全局信息流；**在交付重大工作的 commit/PR 之前追加一行**
+  （`## YYYY-MM-DD · 标题 · #tags` + `What:`/`Refs:`）。细节 → 各 artifact 的 `## Timeline`。
 
-Kinds (now): {{LIST_THE_KINDS_YOU_USE — start with signal + doc; earn more later}}.
-Domains (now): {{LIST_YOUR_LOOPS — or "none yet; run new-loop to create the first"}}.
+当前类别：{{列出你使用的类别 —— 从 signal + doc 开始；后续再挣更多}}。
+当前 domain：{{列出你的循环 —— 或 "暂无；运行 new-loop 创建第一个"}}。
 
-## When spawning agents for code work
-<!-- Only if your loops ship code. Delete if this is a pure ops/content/research setup.
-     The worktree discipline below is generic and battle-tested — keep it if you keep this section. -->
-- **Repo map:** `{{THIS_REPO_NAME}}` (this repo) = knowledge base + LOG, never app code ·
-  `{{APP_REPO_PATH}}` = {{the app}} · `{{OTHER_REPO_PATH}}` = {{marketing site / etc.}}.
-- **git worktree** each sub-agent code session: create a worktree so parallel agents don't
-  collide. Read the target repo's own `CLAUDE.md` for its rules. The `ship-change` workflow
-  does this for you.
-- **Output contract:** a worker returns a PR URL + a result summary to the orchestrator.
-  Knowledge-base updates (READMEs, LOG.md) stay with the orchestrator, not the worker.
-- **Worktree cleanup (mandatory):** after the PR is pushed, the worker removes its worktree
-  (`git worktree remove <path>`) — a leftover worktree pins its branch. Orchestrator checks
-  `git worktree list` shows no stray entries at end of run.
+## 为代码工作派生 agent 时
+<!-- 仅当你的循环会交付代码时才保留。如果是纯运营/内容/研究设置则删除。
+     下面的 worktree 纪律是通用且经受过实战检验的 —— 保留这一节就保留它。 -->
+- **仓库地图：** `{{本仓库名}}`（本仓库）= 知识库 + LOG，绝不是应用代码 ·
+  `{{APP_REPO_PATH}}` = {{应用}} · `{{OTHER_REPO_PATH}}` = {{营销站/等}}。
+- **git worktree** 给每个子 agent 代码会话：创建一个 worktree，让并行 agent 不冲突。
+  阅读目标仓库自己的 `CLAUDE.md` 了解其规则。`ship-change` workflow 会替你做这件事。
+- **输出契约：** 一个 worker 向编排者返回 PR URL + 结果摘要。
+  知识库更新（README、LOG.md）留在编排者手里，不在 worker 手里。
+- **Worktree 清理（强制）：** PR 推送后，worker 移除自己的 worktree
+  （`git worktree remove <path>`）—— 残留的 worktree 会钉住它的分支。编排者在运行结束时
+  检查 `git worktree list`，确认没有遗留条目。
 
-## Links
-- {{PRODUCT}}: {{URL}} · {{ANY_OTHER_KEY_LINKS}}
+## 链接
+- {{产品}}：{{URL}} · {{任何其他关键链接}}

--- a/LOG.md
+++ b/LOG.md
@@ -1,28 +1,28 @@
-# Work log
+# 工作日志
 
-Append-only journal of finished work bulks, so anyone (human or agent) can catch up fast.
-Newest at the BOTTOM. Append an entry whenever a bulk of work wraps (ideally right before
-the commit that ships it). Keep entries SHORT: header line + What + Refs, nothing else.
+已完成工作批次的只追加日志，任何人（人或 agent）都能快速跟上进度。
+最新的在最下方。每当一批工作收尾时追加一条（最好就在交付它的 commit 之前）。
+保持条目简短：标题行 + What + Refs，仅此而已。
 
-**Entry grammar** (strict, one header line per entry):
+**条目语法**（严格，每条一个标题行）：
 ```
-## YYYY-MM-DD · Short title · #tag1 #tag2
-What: 1-2 lines, outcome first.
-Refs: [doc](path) (new|updated), repo PR/commit links.
+## YYYY-MM-DD · 简短标题 · #tag1 #tag2
+What: 1-2 行，结果优先。
+Refs: [doc](path) (new|updated)，仓库的 PR/commit 链接。
 ```
 
-**Tags** (reuse before inventing): add your own as loops emerge, e.g.
+**标签**（先复用再发明）：随着循环出现添加你自己的，例如
 #analysis #product #content #infra #skill #research #ops #revenue #growth
 
-**Retrieval recipes** (macOS; entry headers always start `## 20`):
+**检索配方**（macOS；条目标题始终以 `## 20` 开头）：
 ```bash
-# index of all entries (one line each)
+# 所有条目的索引（每条一行）
 grep '^## 20' LOG.md
-# last 5 entries, full
+# 最近 5 条，完整内容
 tail -r LOG.md | awk '{print} /^## 20/{c++; if(c==5) exit}' | tail -r
-# all entries about a topic
+# 某主题的所有条目
 awk '/^## 20/{p=/#product/} p' LOG.md
-# entries from a month
+# 某月的条目
 awk '/^## 20/{p=/^## 2026-06/} p' LOG.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,90 +1,69 @@
 # loop-engineer-template
 
-A starter template for building **loop engineers**: agents that get triggered on their own,
-pick up work, ship it, verify it, and log what they learned, so the work compounds without you
-prompting every step. It's the productized version of the setup my team runs in production, and
-what I teach at [AI Builder Club](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template).
+一个用于构建**循环工程师（loop engineer）**的启动模板：这类 agent 能自行被触发、领取工作、交付成果、验证结果，并记录所学到的东西，从而让成果在无需你逐步提示的情况下不断复利累积。它是我团队在生产环境中实际运行的这套机制的产品化版本，也是我在 [AI Builder Club](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template) 上所教授的内容。
 
-## What's a loop engineer?
+## 什么是循环工程师？
 
-The shift: you stop prompting a coding agent task-by-task, and start **designing loops**.
+转变在于：你不再逐任务地去提示一个编码 agent，而是开始**设计循环**。
 
-A loop is an agent that wakes up on a trigger (a cron, a webhook, an incident, another agent),
-does some investigation and work, and writes what it found and did into a shared, file-based
-memory. Next run it reads that memory and keeps going. The real power is **compounding**: many
-loops (support, SEO, product, ads) read and write the *same* folders, so a friction the support
-loop logs can get picked up by the product loop, and a keyword the ads loop finds can feed the
-SEO loop. One shared brain, many loops.
+一个循环（loop）就是一个 agent，它会在某个触发条件（定时任务、webhook、一次事故、另一个 agent）下醒来，做一些调研和工作，并把发现与所做的事写进一个共享的、基于文件的记忆里。下一次运行时，它会读取这份记忆并继续推进。真正的力量在于**复利**：许多循环（客服、SEO、产品、广告）读写*同一个*文件夹，因此客服循环记录下的一个摩擦点，可能会被产品循环接手；广告循环发现的一个关键词，可以喂给 SEO 循环。一个共享的大脑，多个循环。
 
-Building one comes down to four ingredients:
+构建一个循环归结为四个要素：
 
-1. **Triggers:** cron, webhook, an incident, or another agent wakes the loop at the right time.
-2. **A file + logging structure:** the shared memory loops read and write (this template).
-3. **Tools & connectors:** so the agent can do real work (your skills/MCPs).
-4. **A codebase harness:** so the agent can run, test, and verify its own work autonomously.
+1. **触发器：** 定时任务、webhook、一次事故，或另一个 agent，在合适的时机唤醒循环。
+2. **文件与日志结构：** 循环读写的共享记忆（本模板）。
+3. **工具与连接器：** 让 agent 能做真正的工作（你的 skills/MCP）。
+4. **代码库 harness：** 让 agent 能自主运行、测试并验证自己的工作。
 
-This repo gives you #2 and #4 out of the box, plus the scaffolding to add the rest.
+本仓库开箱即用地提供了 #2 和 #4，并附上添加其余部分的脚手架。
 
-Want the full walkthrough of the concept and how my team designs compounding loops? Watch the video:
+想要完整了解这个概念，以及我团队如何设计可复利的循环？看这个视频：
 
 [![The loop engineer: how to design compounding agent loops](assets/video-thumbnail.png)](https://youtu.be/W6x-hb44C0c)
 
-## What's included
+## 包含哪些内容
 
 ```
 loop-engineer-template/
-├── ARCHITECTURE.md          the knowledge-base model (read this once)
-├── CLAUDE.md                template for YOUR context: fill in the {{PLACEHOLDER}}s
-├── LOG.md                   global work log (one line per bulk of work)
-├── signals/  docs/  domains/  starter artifact + loop folders, each README IS its schema
+├── ARCHITECTURE.md          知识库模型（读一次即可）
+├── CLAUDE.md                你自己上下文的模板：填入 {{PLACEHOLDER}}
+├── LOG.md                   全局工作日志（每一批工作一行）
+├── signals/  docs/  domains/  启动用的 artifact + 循环文件夹，每个 README 本身就是它的 schema
 └── .claude/
     ├── skills/
-    │   ├── new-loop/                 spin up a new loop (domain): scaffold, test-run, write its contract
-    │   ├── setup-codebase-harness/   the codebase harness: make any repo agent-ready
-    │   ├── dev-local-setup/            └ one-command dev stack
-    │   ├── e2e-setup/                  └ a real e2e test gate
-    │   └── pr/                         └ verify-before-ship (a fresh sub-agent proves it works, then opens the PR)
+    │   ├── new-loop/                 启动一个新循环（domain）：脚手架、试运行、写它的契约
+    │   ├── setup-codebase-harness/   代码库 harness：让任意仓库对 agent 可用
+    │   ├── dev-local-setup/            └ 一条命令的开发栈
+    │   ├── e2e-setup/                  └ 一个真正的 e2e 测试门禁
+    │   └── pr/                         └ 先验证再交付（由一个全新子 agent 证明它可用，再开 PR）
     └── workflows/
-        └── ship-change.js           ship a scoped code change end-to-end (worktree → implement → review → verify → PR)
+        └── ship-change.js           端到端交付一个范围明确的代码变更（worktree → 实现 → review → 验证 → PR）
 ```
 
-- **The knowledge base** (`ARCHITECTURE.md`, `signals/ docs/ domains/`, `LOG.md`) is the shared
-  memory: artifacts filed by kind, domains as loops, every file with an append-only `## Timeline`.
-- **The codebase harness** (the skills under `.claude/skills/`) is what makes a code repo
-  *legible, executable, and verifiable* so loops can ship code without you babysitting them.
+- **知识库**（`ARCHITECTURE.md`、`signals/ docs/ domains/`、`LOG.md`）是共享记忆：artifact 按类别归档，domain 即循环，每个文件都带一个只追加的 `## Timeline`。
+- **代码库 harness**（`.claude/skills/` 下的 skills）让一个代码仓库变得*可读、可执行、可验证*，从而循环能在无需你盯场的情况下交付代码。
 
-## Quickstart
+## 快速开始
 
-1. **Copy this folder** to wherever you want your agent's knowledge base to live.
-2. **Fill in `CLAUDE.md`:** replace every `{{PLACEHOLDER}}`. This is the context the agent reads
-   on every session, so it's the most important step.
-3. **Read `ARCHITECTURE.md`** so you and the agent share the same model. It's short.
-4. **Spin up your first loop.** In Claude Code: run `/new-loop`, then tell it the loop's name,
-   goal, and what it should do. It scaffolds `domains/<loop>/README.md`, does one real test run,
-   and logs it.
-5. **Harness the repo your loop ships into.** Run `/setup-codebase-harness` in that code repo so
-   the agent can run, test, and verify its own work.
-6. **Let it run.** Each session the agent reads `CLAUDE.md` + the relevant domain README, does
-   work, writes artifacts, and appends to `LOG.md`. For code changes it drives `ship-change.js`
-   and ships via `/pr`.
+1. **复制这个文件夹**到你想让 agent 的知识库存放的位置。
+2. **填写 `CLAUDE.md`：** 替换每一个 `{{PLACEHOLDER}}`。这是 agent 每次会话都会读取的上下文，所以是最重要的一步。
+3. **阅读 `ARCHITECTURE.md`**，让你和 agent 共享同一套模型。它很短。
+4. **启动你的第一个循环。** 在 Claude Code 中：运行 `/new-loop`，然后告诉它循环的名字、目标，以及它该做什么。它会脚手架生成 `domains/<loop>/README.md`，做一次真实试运行，并记录下来。
+5. **为你的循环交付代码的目标仓库装配 harness。** 在那个代码仓库里运行 `/setup-codebase-harness`，让 agent 能运行、测试并验证自己的工作。
+6. **让它跑起来。** 每次会话，agent 读取 `CLAUDE.md` + 相关 domain 的 README，做工作，写 artifact，并追加到 `LOG.md`。对于代码变更，它驱动 `ship-change.js` 并通过 `/pr` 交付。
 
-## Requirements
+## 前置要求
 
-- [Claude Code](https://claude.com/claude-code) (the skills + workflow assume it).
-- `git`. That's the only hard dependency.
-- `ship-change.js` and the harness skills want the repo they ship into to be a git repo with a
-  working build/test setup. They use Codex for review if available, and degrade gracefully if not.
+- [Claude Code](https://claude.com/claude-code)（这些 skills + workflow 假定你使用它）。
+- `git`。这是唯一硬性依赖。
+- `ship-change.js` 和这些 harness skills 要求它们交付代码的仓库是一个 git 仓库，并且有可用的构建/测试设置。如果有 Codex 可用，它们会用 Codex 做 review；没有也能优雅降级。
 
-## Go deeper
+## 深入
 
-This template gets you the structure. If you want to learn how to actually build agents and run
-compounding loops for your own business, that's what I go deep on inside
-**[AI Builder Club](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template)**:
-weekly live builder workshops, courses on production AI agents, AI coding beyond the basics, and
-building your first LLM apps, plus a community of people building the same way.
+本模板给你的是结构。如果你想学习如何真正为自有业务构建 agent 并运行可复利的循环，那就是我在 **[AI Builder Club](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template)** 里深入讲解的内容：每周的直播 builder 研讨会、关于生产级 AI agent 的课程、超越基础的 AI 编码，以及构建你的第一批 LLM 应用，外加一群用同样方式在构建的社区。
 
 [![Join AI Builder Club](assets/ai-builder-club.png)](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template)
 
-**→ [Join AI Builder Club](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template)**
+**→ [加入 AI Builder Club](https://www.aibuilderclub.com/lp/loop-engineer?utm_source=github&utm_campaign=loop-engineer-template)**
 
-Built by [Jason Zhou](https://x.com/jasonzhou1993) (AI Jason).
+由 [Jason Zhou](https://x.com/jasonzhou1993)（AI Jason）构建。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,30 +1,30 @@
-# docs/ — durable knowledge
+# docs/ —— 持久知识
 
-One file per **doc**: something you learned, analyzed, or decided that you want to be findable
-later. If a signal is raw evidence, a doc is the worked-through version: an analysis, a writeup,
-a decision and its rationale, a how-it-works note.
+每个 **doc** 一个文件：你学到的、分析的或决定且希望日后可被找到的东西。如果说
+signal 是原始证据，doc 就是加工后的版本：一份分析、一篇 writeup、一个决策及其
+理由、一篇 how-it-works 笔记。
 
-This README is the schema. See `ARCHITECTURE.md` for the model.
+本 README 是它的 schema。模型见 `ARCHITECTURE.md`。
 
 ## Frontmatter
 
 ```yaml
 ---
 kind: doc
-domain: []                  # which loop(s) this belongs to
-status: draft | adopted | superseded   # optional; use when a doc can be acted on or replaced
-links: []                   # related artifacts, [[slug]] or paths
+domain: []                  # 属于哪些循环
+status: draft | adopted | superseded   # 可选；当一个 doc 可被 acted on 或被替换时使用
+links: []                   # 相关 artifact，[[slug]] 或路径
 ---
 ```
 
-Optionally add a `type:` field (e.g. `analysis`, `decision`, `learning`) if you find yourself
-wanting to filter docs by shape — but don't force it. Most docs are just knowledge.
+可选加一个 `type:` 字段（例如 `analysis`、`decision`、`learning`），如果你发现自己
+想按形态过滤 doc —— 但别强求。大多数 doc 只是知识。
 
-## Body
+## 正文
 
-Main text = *what's true now*. Append an optional `## Timeline` for *what happened*
-(revisions, supersessions, when a decision was revisited). Link liberally with `[[slug]]`.
+正文 = *现在什么是真的*。追加一个可选的 `## Timeline` 记录*发生了什么*
+（修订、被取代、一个决策被重新审视时）。用 `[[slug]]` 大量链接。
 
-## Naming
+## 命名
 
-`<short-kebab-slug>.md` or `<TOPIC>-<YYYY-MM>.md` — whatever reads well and sorts sensibly.
+`<short-kebab-slug>.md` 或 `<TOPIC>-<YYYY-MM>.md` —— 读起来顺、排起来合理即可。

--- a/domains/README.md
+++ b/domains/README.md
@@ -1,47 +1,47 @@
-# domains/ — loops
+# domains/ —— 循环
 
-Each subfolder is one **loop**: a thread of work with a charter, a cadence, and (optionally)
-metrics. A domain folder holds only its **`README.md`** (the loop's live state) and optional
-**machinery** (`metrics/*.jsonl`, collectors). It **links** to artifacts in `signals/` and
-`docs/`; it never contains them. The loop's to-dos live inline in the README's `## Backlog`
-(promote to a `task` kind only once that outgrows the README — see `ARCHITECTURE.md`).
+每个子文件夹是一个 **循环**：一段有章程、有节奏、（可选）有指标的工作。一个 domain
+文件夹只持有它的 **`README.md`**（循环的实时状态）和可选的**机器**
+（`metrics/*.jsonl`、采集器）。它**链接** `signals/` 和 `docs/` 里的 artifact；
+它从不包含它们。循环的待办以内联形式活在 README 的 `## Backlog` 里
+（只有当它超出 README 时才升级为 `task` 类别 —— 见 `ARCHITECTURE.md`）。
 
-Don't create domains by hand — run the **`new-loop`** skill. It scaffolds the README from the
-template below, test-runs the loop, and records the run.
+不要手动创建 domain —— 运行 **`new-loop`** skill。它会从下面的模板脚手架生成
+README、试运行该循环、并记录这次运行。
 
-This README is the schema. See `ARCHITECTURE.md` for the model.
+本 README 是它的 schema。模型见 `ARCHITECTURE.md`。
 
-## Domain README template
+## Domain README 模板
 
 ```markdown
 ---
 kind: domain
 domain: <loop-name>
 status: active | paused | archived
-goal: <one line — the outcome this loop drives>
-cadence: <manual | daily | weekly | cron expr — how often it runs>
+goal: <一句话 —— 这个循环要推动的结果>
+cadence: <manual | daily | weekly | cron expr —— 多久运行一次>
 ---
 
-# <loop-name> — <short tagline>
+# <loop-name> —— <简短标语>
 
-<2-4 lines: what this loop does, what it consumes (which signals/data), what it produces.>
+<2-4 行：这个循环做什么、消费什么（哪些 signal/数据）、产出什么。>
 
 ## Current focus
-<The single most important thing this loop is working on right now. Keep it fresh.>
+<这个循环现在正在做的最重要的一件事。保持新鲜。>
 
 ## Backlog
-- [ ] <work item — inline; link [[signal-slug]] / [[doc-slug]] if one exists>
-- [ ] <next thing>
+- [ ] <工作项 —— 内联；如有相关就链接 [[signal-slug]] / [[doc-slug]]>
+- [ ] <下一件事>
 
 ## Evidence & analysis
 [[doc-slug]] · [[doc-slug]]
 
 ## Metrics
-`metrics/` — <which numbers, and the collector that writes them (TBD is fine to start)>.
+`metrics/` —— <哪些数字、以及写它们的采集器（一开始 TBD 也行）>。
 
 ## Timeline
-YYYY-MM-DD | <run/source> — <what happened this run>
+YYYY-MM-DD | <运行/来源> —— <这次运行发生了什么>
 ```
 
-A domain's `## Timeline` is its run-log: one terse dated line per run. Rich per-run detail
-lives in the artifacts it links, not here.
+一个 domain 的 `## Timeline` 是它的运行日志：每次运行一行简短带日期的记录。
+丰富的逐次运行细节活在它链接的 artifact 里，不在这里。

--- a/signals/README.md
+++ b/signals/README.md
@@ -1,36 +1,36 @@
-# signals/ — evidence
+# signals/ —— 证据
 
-One file per **signal**: a piece of feedback, an idea, or an observation worth remembering.
-Signals are **deduped and frequency-counted** — when the same thing shows up again, you don't
-make a new file, you add a Timeline entry to the existing one and bump `frequency`.
+每个 **signal** 一个文件：一条反馈、一个想法、或一条值得记住的观察。
+Signal **去重并按频次计数** —— 当同样的东西再次出现，你不是新建一个文件，
+而是给已有的那个加一条 Timeline 并把 `frequency` 加一。
 
-This README is the schema. See `ARCHITECTURE.md` for the model.
+本 README 是它的 schema。模型见 `ARCHITECTURE.md`。
 
 ## Frontmatter
 
 ```yaml
 ---
 kind: signal
-category: feedback | idea | friction | observation   # what sort of signal
-frequency: 1                # how many times seen; increment on recurrence
-sources: []                 # where it came from (links, ticket ids, urls)
-domain: []                  # which loop(s) this feeds — a list of domain names
+category: feedback | idea | friction | observation   # 信号类型
+frequency: 1                # 被看到多少次；复发时递增
+sources: []                 # 来源（链接、ticket id、url）
+domain: []                  # 喂给哪些循环 —— 一个 domain 名字列表
 status: open | triaged | actioned | closed
 ---
 ```
 
-## Body
+## 正文
 
-A short statement of the signal (what, and why it matters), then an optional append-only
-`## Timeline` accumulating each sighting:
+一段对 signal 的简短陈述（是什么、为何重要），然后是可选的只追加
+`## Timeline`，累积每一次目击：
 
 ```
 ## Timeline
-2026-06-14 | support ticket #123 — user hit the same wall again
+2026-06-14 | 客服 ticket #123 —— 用户又撞到同一堵墙
 ```
 
-`frequency` = number of Timeline entries. Link related artifacts with `[[slug]]`.
+`frequency` = Timeline 条目数。用 `[[slug]]` 链接相关 artifact。
 
-## Naming
+## 命名
 
-`<short-kebab-slug>.md`, or a stable id like `FB-<n>.md` if you prefer running numbers.
+`<short-kebab-slug>.md`，或一个稳定 id 如 `FB-<n>.md`（如果你喜欢用流水号）。


### PR DESCRIPTION
Translate all documentation and agent prompts to Simplified Chinese:
- Root docs: README, CLAUDE, ARCHITECTURE, LOG
- Artifact schema READMEs: signals/, docs/, domains/
- Skills: new-loop, setup-codebase-harness, dev-local-setup, e2e-setup, pr (including frontmatter descriptions used for skill trigger matching)
- ship-change.js: meta description, all phase agent prompts, log output, comments
- dev-local.template.sh: shell comments and user-facing output

Placeholders, frontmatter keys, paths, commands, and code remain untranslated. Technical terms (loop, domain, artifact, signal, doc, worktree, harness) keep English form with Chinese context to stay consistent with code identifiers.