### PR TITLE
fix(crabbox-setup): non-destructive migrate default in setup.sh

### DIFF
--- a/skills/crabbox-setup/assets/setup.sh
+++ b/skills/crabbox-setup/assets/setup.sh
@@ -13,7 +13,11 @@ cd "$(dirname "$0")"
 APP_PORT=3000                      # dev server port
 INSTALL_CMD="pnpm install"
 DEV_CMD="pnpm dev"
-MIGRATE_CMD="pnpm run db:reset"    # set to "" if no migrations
+MIGRATE_CMD="pnpm run db:migrate"  # runs on EVERY setup, incl. LOCALLY (see header) → keep it
+                                   # NON-destructive & idempotent; "" if none. Do NOT default this
+                                   # to a `db:reset`: it would wipe your local dev DB on every
+                                   # re-run. If a fresh box needs seed data, point this at an
+                                   # idempotent migrate-then-seed, not a destructive reset.
 NEEDS_DOCKER=1                     # 1 if you run containers (DB), else 0
 # ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
`setup.sh` is documented as idempotent and explicitly meant to run locally too:

> • locally — `bash setup.sh` boots the same stack on your machine.
> IDEMPOTENT (check-before-act at every step), so it's safe to re-run\n\nBut the default `MIGRATE_CMD="pnpm run db:reset"` runs **unconditionally on every invocation** (`if [ -n "$MIGRATE_CMD" ]; then … $MIGRATE_CMD`). A `db:reset` wipes the database — so following the skill's own instruction to run `bash setup.sh` locally destroys the developer's local dev data on every run. That contradicts the "idempotent / safe to re-run locally" promise.\n\n**Change**\n- Default `MIGRATE_CMD` to a non-destructive `pnpm run db:migrate`.\n- Add an opt-in `SEED_CMD` for the destructive reset+seed a *fresh box* wants, guarded by a sentinel file so it runs once per box and never clobbers a re-run or an existing local DB.\n\nBox seeding still works (set `SEED_CMD="pnpm run db:reset"`); the dangerous default is gone. `bash -n` clean.