### PR TITLE
fix(crabbox-setup): pin @playwright/cli for reproducible snapshots

### DIFF
--- a/skills/crabbox-setup/assets/Dockerfile
+++ b/skills/crabbox-setup/assets/Dockerfile
@@ -40,8 +40,12 @@ RUN corepack enable && corepack prepare pnpm@10.14.0 --activate
 
 # ─── browser e2e (KEEP only if you drive the UI / take screenshots+video) ───
 # Google Chrome = the 'chrome' channel playwright-cli uses by default (NOT chromium).
-RUN npx --yes playwright@1.49.1 install --with-deps chrome \
- && npm install -g @playwright/cli@latest \
+# PIN both: a snapshot must be reproducible — @latest means a rebuild months from now
+# bakes a different (possibly-incompatible) CLI than the one you validated against.
+ARG PLAYWRIGHT_VERSION=1.49.1
+ARG PLAYWRIGHT_CLI_VERSION=0.1.14
+RUN npx --yes playwright@${PLAYWRIGHT_VERSION} install --with-deps chrome \
+ && npm install -g @playwright/cli@${PLAYWRIGHT_CLI_VERSION} \
  && playwright-cli --version
 # playwright's bundled ffmpeg — required for `playwright-cli video-start`.
 RUN node "$(npm root -g)/@playwright/cli/node_modules/playwright-core/cli.js" install ffmpeg


### PR DESCRIPTION
The Dockerfile pins `playwright@1.49.1` but installs the CLI floating:

```dockerfile
RUN npx --yes playwright@1.49.1 install --with-deps chrome \
 && npm install -g @playwright/cli@latest \
```

A Daytona snapshot is meant to be a **reproducible** image. With `@latest`, rebuilding the snapshot months from now bakes a different CLI than the one validated — and the bundled `playwright-core` used a couple lines down for the ffmpeg install drifts with it. Hard-to-debug "works on the snapshot I built, not the one CI rebuilt".

**Change** — pin the CLI to a concrete version (`0.1.14`, current `latest`) and lift both versions into build `ARG`s so they're explicit and overridable:\n\n```dockerfile\nARG PLAYWRIGHT_VERSION=1.49.1\nARG PLAYWRIGHT_CLI_VERSION=0.1.14\n```