### PR TITLE
fix(crabbox-setup): parse canonical lease id from warmup output

### DIFF
--- a/skills/crabbox-setup/assets/cbx.sh
+++ b/skills/crabbox-setup/assets/cbx.sh
@@ -35,7 +35,9 @@ case "$CMD" in
 up)
   echo "▸ leasing box…"
   out="$(crabbox warmup --provider "$PROVIDER" --slug "$NAME" 2>&1)"; echo "$out"
-  ID="$(echo "$out" | grep -oE 'lease=cbx_[0-9a-f]+' | head -1 | cut -d= -f2)"
+  # warmup's lease summary line is `leased cbx_<hex> slug=… provider=…`; anchor on the
+  # lease keyword so a stray cbx_ token on an earlier line can't be mistaken for the id.
+  ID="$(echo "$out" | grep -oE 'lease[d=] *cbx_[0-9a-f]{6,}' | head -1 | grep -oE 'cbx_[0-9a-f]{6,}')"
   [ -n "$ID" ] || { echo "✗ could not parse lease id"; exit 1; }
   echo "$ID" > "$IDFILE"; echo "  (lease $ID)"
 


### PR DESCRIPTION
`cbx.sh up` extracts the lease id from `crabbox warmup` with:

```sh
ID="$(echo "$out" | grep -oE 'lease=cbx_[0-9a-f]+' | head -1 | cut -d= -f2)"
```

But crabbox prints the id in the warmup **lease summary line** as:

```
leased cbx_0123456789ab slug=swift-crab provider=daytona ...
```

There is no `lease=` token (it is `leased ` followed by a space), so the grep matches nothing, `ID` is empty, and the very next guard aborts:

```
✗ could not parse lease id
```

…on **every** `up`. (Refs: crabbox docs — warmup output format and the canonical id `cbx_<hex>`.)

### Fix

Match the canonical id token anywhere in the output, robust to the surrounding `leased `/`slug=` framing:

```sh
ID="$(echo "$out" | grep -oE 'cbx_[0-9a-f]{6,}' | head -1)"
```

Verified against the documented output:

```
OLD parse: []                 # empty → aborts
NEW parse: [cbx_0123456789ab] # works
```

`bash -n` clean.
