### PR TITLE
Add seo-growth skill: two SEO playbooks from production

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skills",
-  "description": "Build loop engineers: a file-based knowledge base your agents read/write (loops), plus a codebase harness (dev-local stack, e2e gate, an isolated cloud box per agent via crabbox, and verify-before-ship) so loops can run, test, and ship code autonomously.",
+  "description": "Build loop engineers: a file-based knowledge base your agents read/write (loops), plus a codebase harness (dev-local stack, e2e gate, an isolated cloud box per agent via crabbox, and verify-before-ship) so loops can run, test, and ship code autonomously. Plus an SEO growth playbook distilled from two production content properties.",
   "version": "0.1.0",
   "author": {
     "name": "Jason Zhou (AI Jason)",
@@ -21,6 +21,11 @@
     "visualization",
     "delegation",
     "tmux",
-    "multi-agent"
+    "multi-agent",
+    "seo",
+    "content-strategy",
+    "search-console",
+    "keyword-research",
+    "growth"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Plus standalone utility skills:
 - **Open agent teams** — delegate tasks to *any* CLI agent (claude, codex, grok, aider, …)
   running in a detached tmux session, with a race-safe done-signal protocol, multi-turn
   iteration, and a CLAUDE.md delegation-rules template (coordinator/executor roles).
+- **SEO growth** — where to point SEO effort, as two playbooks: a **cold start** with no
+  rankings and no authority, and an **existing site with data**. Distilled from two content
+  properties we run in production — including the emerging-term method that took a brand-new
+  pillar page to the site's #1 clicked page in 7 days, and the failures that cost us a head
+  term. Ships a loop template so it can run on a schedule.
 
 ## Loop engineer & Codebase harness
 

--- a/skills/seo-growth/SKILL.md
+++ b/skills/seo-growth/SKILL.md
@@ -8,9 +8,8 @@ description: >
   "should we build a cluster or one page", "what do we write next", "we get impressions
   but no clicks", "our traffic plateaued despite publishing", whether to chase a head
   term at all, or turning any of it into recurring automation. Also use when asked why
-  an SEO effort stalled despite consistent output. NOT for writing an article
-  writing an article, keyword expansion mechanics, or auditing a single tactic for
-  penalty risk.
+  an SEO effort stalled despite consistent output. NOT for writing an article,
+  keyword expansion mechanics, or auditing a single tactic for penalty risk.
 ---
 
 # /seo-growth — first-party SEO growth method
@@ -20,10 +19,9 @@ is given to the wrong one of those two situations.** A site with no rankings and
 breadwinner page need opposite behavior. Advice that ignores which you are in is how efforts
 stall despite consistent output.
 
-Distilled from two content properties run in production by AI Builder Club — one
-developer-education site, one design-tool site — and the Search Console reads that produced
-each rule. This is **first-party method**: narrower than a general playbook, and more
-trustworthy for it. Every rule traces to the failure or result behind it in
+Distilled from two content properties run in production and the Search Console reads that
+produced each rule. This is **a first-party method**: narrower than a general playbook, and
+more trustworthy for it. Every rule traces to the failure or result behind it in
 `references/why-these-rules.md`. Absolute traffic figures are withheld; the ratios and
 thresholds are as observed.
 
@@ -73,9 +71,9 @@ it is the most common failure mode in this whole area.
 2. **Score an emerging term on position, a mature one on clicks.** Backwards, and the metric
    tells you to quit the land-grab exactly as the ground becomes valuable — or leaves a page at
    0.53% CTR untouched for a month because its rank looked fine.
-3. **Impressions are not progress.** The trap is a page pulling six figures of impressions at
-   0.2% CTR. It feels like traction and converts nothing. Rank work by click opportunity from
-   *human* queries.
+3. **Impressions are not progress.** The trap is a page drawing a very large impression base
+   relative to the rest of the site at 0.2% CTR. It feels like traction and converts nothing.
+   Rank work by click opportunity from *human* queries.
 4. **Concentration is the goal, not the problem.** One page earning ~45% of clicks is healthy.
    Compound the winner before adding breadth.
 5. **What you double down on is derived, not chosen.** Read your own GSC for which *shapes*
@@ -110,11 +108,10 @@ it is the most common failure mode in this whole area.
 
 ## Scope honesty
 
-Derived from B2B / developer-tool / creator-education content SEO on low-to-mid authority
-domains. The two-playbook split, the measurement discipline, and the emerging-term method
-transfer broadly. The specific archetypes in `with-data.md` do not — they are one property's,
-and yours must be extracted from your own data. Local, e-commerce, and YMYL were never tested
-here; say so rather than extrapolating.
+Derived from B2B content SEO on low-to-mid authority domains. The two-playbook split, the
+measurement discipline, and the emerging-term method transfer broadly. The specific archetypes
+in `with-data.md` do not — they are one property's, and yours must be extracted from your own
+data. Local, e-commerce, and YMYL were never tested here; say so rather than extrapolating.
 
 ## What this skill deliberately does not cover
 

--- a/skills/seo-growth/SKILL.md
+++ b/skills/seo-growth/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: seo-growth
+description: >
+  Use when deciding WHERE to point SEO effort, not how to write a page. Triggers: a new
+  site or brand with no rankings and no authority ("cold start", "starting from zero",
+  "nobody knows us"), deciding what to double down on, a page or cluster that ranks but
+  earns nothing, hunting emerging or newly-coined keywords before competitors arrive,
+  "should we build a cluster or one page", "what do we write next", "we get impressions
+  but no clicks", "our traffic plateaued despite publishing", whether to chase a head
+  term at all, or turning any of it into recurring automation. Also use when asked why
+  an SEO effort stalled despite consistent output. NOT for writing an article
+  writing an article, keyword expansion mechanics, or auditing a single tactic for
+  penalty risk.
+---
+
+# /seo-growth — first-party SEO growth method
+
+**Core principle: the right move depends on whether you have data yet, and most bad SEO advice
+is given to the wrong one of those two situations.** A site with no rankings and a site with a
+breadwinner page need opposite behavior. Advice that ignores which you are in is how efforts
+stall despite consistent output.
+
+Distilled from two content properties run in production by AI Builder Club — one
+developer-education site, one design-tool site — and the Search Console reads that produced
+each rule. This is **first-party method**: narrower than a general playbook, and more
+trustworthy for it. Every rule traces to the failure or result behind it in
+`references/why-these-rules.md`. Absolute traffic figures are withheld; the ratios and
+thresholds are as observed.
+
+## The two playbooks
+
+| You are here if… | Playbook | Read |
+|---|---|---|
+| No rankings, no authority, <100 clicks/mo, possibly no content | **A — Cold start** | `references/cold-start.md` |
+| GSC has real rows: something ranks, something earns clicks | **B — With data** | `references/with-data.md` |
+
+**Diagnose per cluster, not per site.** A mature site opening a new territory is in Playbook A
+for that territory and Playbook B everywhere else — and that combination is the strongest
+position in the method.
+
+**Playbook A in one line:** you cannot win an established term from zero authority, so hunt an
+emerging one, ship ONE page, and let day-7 / day-21 decide whether it was real.
+
+**Playbook B in one line:** your own GSC already knows which page shapes win for you — find the
+breadwinner, extract the shape, diagnose whether it is position-limited or snippet-limited,
+compound it, and protect it while you do.
+
+## Read alongside either playbook
+
+- **`references/emerging-terms.md`** — the hunt. The wedge in both playbooks, and the *only*
+  thing that works in Playbook A. Where to look, in what order, and the seven gates a candidate
+  must pass.
+- **`references/measurement.md`** — which metric scores which situation, the four query
+  families that never click, and the GSC traps that produce confident wrong conclusions.
+- **`references/why-these-rules.md`** — the failure or result behind each rule.
+- **`references/operationalize.md`** — turning either playbook into scheduled loops.
+
+## Before advising anything: get three numbers
+
+Pull a 28-day GSC window ending **3 days back** (GSC lags 2–3 days):
+
+1. **Total clicks** — the scale, and which playbook you are in.
+2. **Breadwinner share** — what % of clicks the single best page earns.
+3. **Best non-brand position** — where you rank on something you don't own by name.
+
+If these aren't available, say so and instrument first. Advising without them is guessing, and
+it is the most common failure mode in this whole area.
+
+## The five laws
+
+1. **A low-authority domain can only win a term while competition is thin.** So a cold start
+   doesn't "do SEO" — it hunts emerging terms. Validated on two separate terms, months apart.
+2. **Score an emerging term on position, a mature one on clicks.** Backwards, and the metric
+   tells you to quit the land-grab exactly as the ground becomes valuable — or leaves a page at
+   0.53% CTR untouched for a month because its rank looked fine.
+3. **Impressions are not progress.** The trap is a page pulling six figures of impressions at
+   0.2% CTR. It feels like traction and converts nothing. Rank work by click opportunity from
+   *human* queries.
+4. **Concentration is the goal, not the problem.** One page earning ~45% of clicks is healthy.
+   Compound the winner before adding breadth.
+5. **What you double down on is derived, not chosen.** Read your own GSC for which *shapes*
+   win, then repeat the shape — not just the page.
+
+## Quick reference
+
+| Question | Short answer | Detail |
+|---|---|---|
+| Cold start, what now? | Instrument, then land ONE emerging term. Not a cluster. | cold-start |
+| Cluster or one page? | One page until the term proves itself. Cluster after. | cold-start |
+| How do I find emerging terms? | Your own saved stream → repo/release feeds → social listening → diff vs your pages | emerging-terms |
+| Is this term worth it? | Seven gates; failing one drops it, and dropping is normal | emerging-terms |
+| What do we double down on? | The page at ≥30% of clicks — and the archetype it belongs to | with-data |
+| Ranks well, no clicks? | Screen the query mix first. Most such pages are not broken. | with-data, measurement |
+| Traffic plateaued despite publishing | The cluster saturated. Open a new front, don't add pages to it. | with-data §7 |
+| When do I stop land-grabbing? | Three computable numbers, never a vibe | measurement |
+| How do I stop doing this by hand? | Four loop roles, never one loop | operationalize |
+
+## Common mistakes
+
+- **Advising before diagnosing.** Get the three numbers first.
+- **Treating every low-CTR page as broken.** Four query families score ~zero clicks by design;
+  one verified family ranked position 4.7–5.8 for **exactly 0 clicks** and was working
+  perfectly.
+- **Publishing on a cadence instead of on evidence.**
+- **Diversifying away from a winner** because concentration feels risky.
+- **Grounding research on your own pages and your own GSC.** A closed loop. It produces internal
+  reshuffles that cannot move a term you don't yet own — one property lost its head term to
+  page 2 this way while the answer sat unread in the owner's own bookmarks.
+- **Counting a ship as an outcome.** A shipped page is a hypothesis until traffic verifies it.
+
+## Scope honesty
+
+Derived from B2B / developer-tool / creator-education content SEO on low-to-mid authority
+domains. The two-playbook split, the measurement discipline, and the emerging-term method
+transfer broadly. The specific archetypes in `with-data.md` do not — they are one property's,
+and yours must be extracted from your own data. Local, e-commerce, and YMYL were never tested
+here; say so rather than extrapolating.
+
+## What this skill deliberately does not cover
+
+- **Penalty risk / what Google punishes.** Read current third-party research before shipping at
+  any scale — Lily Ray on algorithmic collapses, Kevin Indig on how AI systems select sources,
+  Rand Fishkin and Amanda Natividad on zero-click. This skill is about *where to aim*, not about
+  which tactics are dangerous, and the two are different questions.
+- **Writing the page.** Use whatever content skill or process you already have. The bar this
+  method assumes: genuine first-party substance, 15+ concrete specifics, and an answer a
+  competitor cannot regenerate from the same prompt tomorrow.
+- **Keyword expansion mechanics.** Once you know the territory, any keyword tool will widen it.
+
+## Companion skills in this plugin
+
+- **`new-loop`** — build the scheduled loop that runs either playbook on a cadence. See
+  `references/operationalize.md` and `assets/seo-loop-template.md`.

--- a/skills/seo-growth/assets/seo-loop-template.md
+++ b/skills/seo-growth/assets/seo-loop-template.md
@@ -1,0 +1,143 @@
+# SEO Engine — loop template
+
+A fill-in-the-blanks brief for a scheduled SEO loop. Replace every `<FILL: …>`, delete the
+SETUP block, then point your scheduler at it.
+
+**Do not enable this until you have run the playbook by hand a few times.** Automating an
+undiagnosed site produces confident output aimed at the wrong work, faster. The reasoning
+behind every rule below is in this skill's `references/`.
+
+**Recommended guard:** have the pre-run step count remaining `<FILL: …>` markers and refuse to
+invoke the agent while any remain. A half-configured loop then cannot ship anything.
+
+---
+
+## SETUP — delete once every box is ticked
+
+- [ ] Search Console access works. You can pull query-dim and page-dim rows for
+      `<FILL: yourdomain.com>`. Run it once by hand first.
+- [ ] **Pick the regime** below and delete the branch you are not in.
+- [ ] **Name your breadwinner** — the page earning ≥30% of clicks. Don't know it? You aren't
+      ready; measure for a week first.
+- [ ] **Write your carve-out** — the query families that will never click. Do this BEFORE run 1
+      or your KPI will lie to you.
+- [ ] **Name sibling loops** and their owned pages, or write "none yet."
+- [ ] Start PR-only. Earn autonomy later.
+
+---
+
+## Spec
+
+**Mission:** <FILL: own head term X / grow clicks on surface Y> for <FILL: brand>. The reader's
+next step is <FILL: course, signup, newsletter, community>.
+
+**Property:** `<FILL: yourdomain.com>` · **Repo:** `<FILL: path>` · **Content:** `<FILL: glob>`
+
+**Open monitor, no finish line.** Each run reports the score against its target and flags
+movement in or out of it. If runs degenerate into measure-and-skip, slow the cadence rather
+than forcing thin work.
+
+### Regime — pick ONE
+
+**[ ] LAND-GRAB** — emerging term, thin SERP, demand still forming.
+- North star: **exact-head position (hold ≤3) + family footprint.**
+- Default unit: ship ONE cluster article.
+- Clicks are a **graduation tripwire**, not a score.
+- **Flip gate (report all three numbers every run):** move to HARVEST when
+  `family_top3_share ≥ 85%` AND `family_queries` grew <10% vs prior run AND `family_weak ≤ 2`.
+
+**[ ] HARVEST** — pages live, demand established.
+- North star: **clicks.** Position is a diagnostic and does not decide the work.
+- Default unit: one enrichment on the highest click-opportunity page.
+- Name the KPI's successor (clicks → <FILL: conversion>) and say honestly whether it is
+  instrumented. Never fake it from what Search Console can reach.
+
+### Carve-out — families that score zero BY DESIGN. Do not optimize these away.
+
+<FILL: your verified non-clicking families>
+
+Screen every low-CTR page against: **LLM fan-out** (no human to click) · **competitor-
+navigational** (they want the competitor's site) · **brand-navigational** (your homepage should
+win it) · **anonymized tail** (visible impressions <10% of total = undiagnosable).
+
+### Scope
+
+Owns: <FILL: pages>. **Never touches:** <FILL: sibling loop's pages, including your crown jewel>.
+Before editing ANY page, check whether a sibling loop touched it in the last 7 days. If so, skip.
+
+---
+
+## Each run, in order
+
+**0. Reconcile against the live system.** Key on **URL, not title** — titles get rewritten at
+publish. If state drifted, fix it first; everything downstream is meaningless on a false model.
+
+**0b. Verification ledger.** For every applied change whose `verify_after` has passed: compare
+that page's clicks 7d-after vs 7d-before. Human traffic down >30% → flag a **revert
+recommendation** naming the change, page, numbers, and commit. **Never revert yourself.**
+Otherwise stamp it verified.
+
+**1. Read state.** This file's Current understanding + last Timeline entry + recent commits.
+Never re-ship something already covered or in flight.
+
+**2. Read the score.** Use pre-staged data; do not re-fetch what a deterministic pre-stage
+already pulled — that is the largest cost sink these loops have. Window: 28 days ending 3 days
+back.
+
+**2b. Deployment check.** Count unmerged units. **An unmerged page is not live** — while
+anything is unmerged, flat position is expected, not failure.
+
+**2c. Canary + cooldowns.** Breadwinner position drop ≥3 or clicks drop >30% → flag it first and
+queue no edits against it. Cooldowns: breadwinner 14 days, other pages 7 days. One edit per page
+per window, or you cannot attribute the result.
+
+**3. Pick ONE unit** and log why the data chose it. Menu by leverage: internal link equity into
+the page you're compounding · query-match title/H1/meta to the human query the page ranks for
+but never names · fresh PAA-style FAQ · tighten the answer into the first 30% · extraction
+structuring · follow through on a flagged verification.
+
+**4. Screen the candidate for human intent** before touching it. Non-human → next candidate.
+
+**5. Mine the freshness gap.** Your own curated stream FIRST, then repo/release feeds, then
+social listening, then diff against your own pages. **Grounding only on your own data is a
+closed loop.** Cite the source that motivated the pick.
+
+**6. Gates — all must hold, or ship nothing.** Cannibalization pre-check (no page of yours at
+pos <15 for the target) · CTA test answered in writing · every new technical specific verified
+against a **primary source** this run · queue depth under <FILL: n> · voice check on final copy.
+
+**7. Ship.** Branch off `origin/main` after a fetch — never local main, never commit to main.
+PR body: target, evidence, the numbers, the CTA answer, before→after, the doc URL you checked.
+Stamp `applied:` and `verify_after: +14d`.
+
+**8. Report.** Write a dated run report. Append one Timeline entry. Emit metrics. Notify on:
+KPI fell, drift found, canary tripped, a revert recommendation, or nothing cleared the gate for
+3+ runs.
+
+### Hard rules
+
+Never auto-publish <FILL: what stays human-gated>. Never fabricate a metric or quote — use
+`[NEED: …]`. Never date-bump without a real change, but DO bump it when the change is real.
+Never target a head term one of your own pages already ranks pos <15 for. Respect cooldowns.
+Keep heavy work out of any synced folder.
+
+---
+
+## Current understanding
+
+*Seed before run 1, never let it go stale. This section — not the automation — is where the
+compounding lives. A loop that re-derives its conclusions every run is an expensive cron job.*
+
+- Baseline (<FILL: date>): KPI <FILL:>, head position <FILL:>, breadwinner <FILL:> at <FILL:>%.
+- **Verified non-problems — do not re-triage:** <FILL:>
+- **Ruled out, and why:** <FILL: so a future run doesn't re-pitch them>
+- **Ledger of applied changes:** <FILL:>
+- **Environment gotchas:** <FILL: each one costs a run to rediscover>
+
+**Two runtime traps true of any scheduled agent loop:** a run dies the instant the agent yields
+the turn, so backgrounded work and "notify me later" waits die with it — long steps must be
+blocking foreground calls. And a long run can lose its lease if the machine sleeps; keep runs
+short and chunk anything lengthy.
+
+## Timeline
+<!-- one dated entry per run -->

--- a/skills/seo-growth/references/cold-start.md
+++ b/skills/seo-growth/references/cold-start.md
@@ -1,0 +1,112 @@
+# Playbook A — Cold start (no data yet)
+
+**You are here if:** <100 clicks/month, nothing ranking top-20, no domain authority, possibly
+no content at all.
+
+**The one thing to understand:** a low-authority domain **cannot** win an established head
+term. Not with better writing, not with more pages, not with more patience. It can only win a
+term **while competition is still thin.** So a cold start does not "do SEO" in the ordinary
+sense — it hunts emerging terms and lands on them before anyone else. That is the entire
+entire cold-start strategy. Everything below is how.
+
+Validated on two separate emerging terms months apart. On the second, the pillar became the
+site's #1 clicked page **within 7 days of launch**. Neither would have been possible against an
+established term.
+
+---
+
+## The sequence
+
+### 1. Instrument before you write. (Week 0, no content.)
+
+You cannot run any of this without a live GSC property. Set it up, verify a query returns
+rows, and record the zero baseline. A cold start that skips this cannot tell a real signal
+from noise for its first three months — and the whole method is signal-driven.
+
+Record: total clicks, total impressions, top 10 queries (probably brand-only or empty). That
+is your baseline. Write it down with the date.
+
+### 2. Answer the CTA test before choosing anything.
+
+> **"What will the reader DO after finishing this page?"**
+
+If the honest answer is "close the tab," the topic fails — no matter how emerging, rankable,
+or interesting. This is a **hard gate**, and in a cold start it is the difference between building
+an audience and building a vanity traffic chart.
+
+The searcher must be **mid-workflow** — setting something up, building something, adopting a
+technique — with a natural next step into what you sell or run. A news reader comparing
+options has no next step.
+
+Search Console confirms this empirically. On one property, news and announcement pieces each
+earned five-to-six figures of impressions and nearly nothing else:
+
+| Page shape | CTR |
+|---|---|
+| "Google kills <tool>" news guide | 0.4% |
+| "<Tool> complete guide" (launch news) | 0.2% |
+| "Best [category] 2026" roundup | **0.04%** |
+
+Those are not near-misses. They are the shape failing. **A cold start that chases news gets
+impressions and no business**, and impressions feel enough like progress to waste a quarter.
+
+### 3. Hunt ONE emerging term.
+
+Full method in `emerging-terms.md`. The short version: find a term, tool, file format, or
+convention that surfaced in the last ~30 days, where search intent is visibly forming ("what
+is X", "how to X") and no dedicated well-optimized article is ranking yet.
+
+In a cold start, prefer a term **attached to a person or a named artifact.** That archetype
+compounds hardest and is easiest to spot early.
+
+### 4. Ship ONE page. Not a cluster.
+
+This is where most cold starts go wrong: they plan a 12-article content calendar for a term
+that has not yet proven it has demand. **One pillar page. Then wait.**
+
+The page must be genuinely the best thing on the internet for that term, which is achievable
+precisely because nothing else exists yet. Use whatever writing process you have; the bar that
+matters here is first-party substance — 15+ concrete specifics, real diagrams, honest
+methodology. A page a competitor can regenerate from the same prompt tomorrow will not hold.
+
+### 5. Measure at day 7, decide at day 21.
+
+Emerging terms move **fast** — that is their signature and how you know you picked a real one.
+
+- **Day 7:** is anything ranking at all? On a genuinely open SERP a good page lands top-10
+  within days, not months.
+- **Day 21:** if the term still shows near-zero impressions, **the term was not real.** Do not
+  iterate on it, do not rewrite it, do not build its cluster. Log why it failed and hunt
+  again. The failure is cheap only if you stop.
+- **If it landed:** now build the cluster, and switch to `with-data.md`.
+
+The asymmetry is the point: a wrong pick costs one article, a right pick compounds for months.
+
+### 6. Only after a term proves out, widen.
+
+Ship cluster articles around the proven term, each a **distinct sub-intent** — never a keyword
+restatement of the pillar. Every article links up to the pillar with descriptive anchor text;
+the pillar links down. Value is front-loaded: land clusters while you still own the SERP,
+because as competitors wake up your position and CTR normalize down even as impressions climb.
+
+---
+
+## What NOT to do in a cold start
+
+| Tempting | Why it fails here |
+|---|---|
+| Target the obvious head term for your category | You have no authority. You will rank nowhere for months and learn nothing. |
+| Publish on a weekly cadence to "build momentum" | Templated publishing at scale is a documented collapse pattern in the algorithmic-risk research. Publish on evidence, not on a calendar. |
+| Write "best X" / "X vs Y" / "X alternatives" | Highest competition, lowest CTR, and the listicle shape can actively exclude you from AI recommendations. |
+| Chase the news cycle | See the table above. Impressions without a next step. |
+| Build a 12-article calendar before anything ranks | You are betting a quarter on an unvalidated term. |
+| Optimize the pages you have | You have no data yet. There is nothing to optimize toward. |
+
+---
+
+## Exit criteria → Playbook B
+
+You leave cold start when **one term is genuinely landed**: a page ranking top-10 on a
+non-brand term that throws real impressions and real clicks. Then read
+`with-data.md` — the job changes from "find any signal" to "learn which shapes win
+for you."

--- a/skills/seo-growth/references/cold-start.md
+++ b/skills/seo-growth/references/cold-start.md
@@ -7,7 +7,7 @@ no content at all.
 term. Not with better writing, not with more pages, not with more patience. It can only win a
 term **while competition is still thin.** So a cold start does not "do SEO" in the ordinary
 sense — it hunts emerging terms and lands on them before anyone else. That is the entire
-entire cold-start strategy. Everything below is how.
+cold-start strategy. Everything below is how.
 
 Validated on two separate emerging terms months apart. On the second, the pillar became the
 site's #1 clicked page **within 7 days of launch**. Neither would have been possible against an
@@ -39,12 +39,12 @@ technique — with a natural next step into what you sell or run. A news reader 
 options has no next step.
 
 Search Console confirms this empirically. On one property, news and announcement pieces each
-earned five-to-six figures of impressions and nearly nothing else:
+earned a very large impression base relative to the rest of the site and nearly nothing else:
 
 | Page shape | CTR |
 |---|---|
-| "Google kills <tool>" news guide | 0.4% |
-| "<Tool> complete guide" (launch news) | 0.2% |
+| "Google kills [tool]" news guide | 0.4% |
+| "[Tool] complete guide" (launch news) | 0.2% |
 | "Best [category] 2026" roundup | **0.04%** |
 
 Those are not near-misses. They are the shape failing. **A cold start that chases news gets

--- a/skills/seo-growth/references/emerging-terms.md
+++ b/skills/seo-growth/references/emerging-terms.md
@@ -1,0 +1,135 @@
+# Hunting emerging terms — the wedge
+
+**This is the highest-leverage skill in the whole method**, and the only one that works from
+zero authority. Both playbooks need it: Playbook A lives on it entirely, and a site with data
+uses it to open the next front once a cluster saturates.
+
+**Why it works:** ranking is a competition. On an established term you are competing against
+domains with years of authority and you lose. On a term that surfaced three weeks ago, nobody
+has authority yet — the SERP is decided by who shows up with the best page first. Authority
+stops being the deciding variable. That window closes as the term matures, so **value is
+front-loaded: ship while you own it.**
+
+---
+
+## The pattern to look for
+
+The internal shorthand is **"the karpathy-md pattern"**, after the convention that produced one
+property's crown-jewel page — its best performer by a wide margin at ~2.3% CTR, with five more
+pages from the same cluster in the site's top 30.
+
+The shape:
+
+> A **new term, tool, file format, or convention** — usually attached to a **named person or
+> artifact** — that appeared or spiked in the last ~30 days, where people have started asking
+> "what is X" / "how do I X", and no dedicated well-optimized article ranks for it yet.
+
+Person-attached and artifact-attached terms are the strongest signal because they are
+**nameable**: people search the exact string, which means the intent is unambiguous and a
+single page can own it.
+
+---
+
+## Where to hunt — sourcing order matters
+
+Run these **in this order**, every hunt. The order is not cosmetic; it was derived from a
+documented failure.
+
+### 1. Your own curated stream — FIRST, and not optional
+
+Whatever you already save because it interests you: bookmarks, saved threads, a reading list,
+a Slack channel you dump links in. This is the freshest, highest-signal corpus you have, and
+it is where a term shift shows up before it is anywhere else.
+
+**The named failure:** an automated SEO process ran for nine days grounding only on its own
+pages and its own Search Console data, shuffling internal links, while its head term slipped to
+page 2. The entire industry term shift it needed to react to was sitting unread in the owner's
+own saved bookmarks, added days earlier. The process had the answer and never looked at it.
+
+**Grounding on your own data is a closed loop.** It produces internal reshuffles that cannot
+move a term you do not yet own.
+
+### 2. Repo and release feeds — the outside gap
+
+GitHub trending repos and recent releases in your territory; X threads and framings from the
+last ~2 weeks. This surfaces new tools and new terminology before search volume exists.
+
+### 3. Social listening — corroboration, not discovery
+
+One input, not the only one. Pull what people are actually saying and asking across Reddit, X,
+Hacker News, and YouTube over the last ~30 days. Use it to confirm intent is forming and to find
+the exact phrasing people use — the phrasing matters more than the topic, because it is what
+they will type.
+
+*Practical note:* whatever tool you use for this, broad topics tend to be slow or time out. When
+that happens, drop to a few scoped web searches rather than re-running the broad pull.
+
+### 4. Diff against your own coverage
+
+grep your existing pages. **The delta is the target.** New framings, new tools, term shifts,
+uncovered sub-questions. Cite the specific bookmark, repo, or thread that motivated the pick,
+so the source trail is auditable and a future you can tell a real signal from a hunch.
+
+---
+
+## The validation gates — ALL must pass
+
+A candidate that fails any one of these is dropped, and dropping is the common outcome. Log
+rejections with reasons; a rejected-candidate list stops you re-pitching the same loser.
+
+| Gate | Test | Fail = drop |
+|---|---|---|
+| **Emerging** | Term surfaced or spiked in the last ~30 days | An old term means an established SERP |
+| **Intent forming** | People visibly asking "what is X" / "how to X" | A term nobody searches is a blog post, not SEO |
+| **Rankable** | No dedicated, well-optimized article dominating | If one exists, you are back to authority competition |
+| **In-domain** | Your audience would genuinely search this | Off-domain traffic does not convert and dilutes the site |
+| **You can answer it** | You have first-party substance, not a rewrite | A page anyone could regenerate will not hold |
+| **CTA test** | The reader has a native next step into your funnel | "Close the tab" = fail, no exceptions |
+| **No cannibalization** | No page of yours already ranks pos <15 for it | You would split your own click equity — link instead |
+
+### The cannibalization pre-check, concretely
+
+Before committing to a target term, query GSC by **page** dimension filtered to that term. If
+one of your own pages already ranks **position <15**, do not build a second page for it. Pick
+a distinct long-tail the existing page does not own, and **link to** the existing page instead
+of competing with it. Two of your pages on one query is not coverage, it is splitting.
+
+---
+
+## Validating demand when there is no volume data yet
+
+The trap: keyword tools show ~0 volume for a genuinely emerging term, because volume data lags
+weeks to months. **Absence of volume is not absence of demand** at this stage — it is the
+signal you are early.
+
+So validate on **leading indicators** instead:
+- Are related queries already appearing in your own GSC impressions? (Even a handful.)
+- Is engagement visible in the raw discourse — thread replies, repo stars, video comments?
+- Is the term being used *as a term* by more than one independent person? (One person's coinage
+  is not a term yet; three is a wave.)
+
+Then let day-7 / day-21 measurement settle it (see `cold-start.md`).
+
+---
+
+## Cadence
+
+Run the hunt on a **weekly** rhythm, not continuously. Emerging terms do not appear daily, and
+hunting more often just produces forced picks.
+
+**A week where nothing clears the bar is a valid, correct outcome.** Log "no qualifying
+candidate" with the rejected list and why. A forced thin article actively hurts the cluster it
+attaches to — it is worse than nothing, not neutral.
+
+**Saturation cooldown:** once a topic's hunt reads "saturated" (you already own every intent
+worth owning), do not re-mine it for ~14 days. Saturation is a healthy steady state, not a
+shortfall. One property read saturated across seven consecutive runs; the correct response was
+to stop paying for the same answer, not to invent new angles.
+
+---
+
+## After it lands
+
+Emerging terms mature. Watch for the **graduation tripwire**: when the term starts throwing
+real click volume and its family stops widening, the land-grab is over and the work shifts to
+compounding and conversion. The computable version of that flip is in `measurement.md`.

--- a/skills/seo-growth/references/emerging-terms.md
+++ b/skills/seo-growth/references/emerging-terms.md
@@ -14,9 +14,8 @@ front-loaded: ship while you own it.**
 
 ## The pattern to look for
 
-The internal shorthand is **"the karpathy-md pattern"**, after the convention that produced one
-property's crown-jewel page — its best performer by a wide margin at ~2.3% CTR, with five more
-pages from the same cluster in the site's top 30.
+The **person-attached emerging-artifact pattern** produced one property's crown-jewel page —
+its best performer by a wide margin at ~2.3% CTR.
 
 The shape:
 

--- a/skills/seo-growth/references/measurement.md
+++ b/skills/seo-growth/references/measurement.md
@@ -1,0 +1,118 @@
+# Measurement — which metric, and the traps
+
+Read this before trusting any number. Most stalled SEO efforts are not doing the wrong work;
+they are grading it with the wrong metric, and the metric quietly points them at the wrong
+work forever.
+
+---
+
+## The regime question: position or clicks?
+
+**Score an emerging term on POSITION. Score a mature one on CLICKS.** Getting this backwards
+is the single most expensive metric error in the method, and it fails in both directions.
+
+### Why clicks is the wrong score for an emerging term
+
+One property's emerging head term went from **zero impressions to substantial weekly volume in
+about four weeks**, while its rank sat at ~position 7 the whole time. Graded on clicks that
+reads "barely any traffic, meh" — and tells you to abandon the land-grab **exactly as the
+ground is becoming valuable**. You never rank an emerging keyword if you wait for its clicks
+first.
+
+While land-grabbing, score on:
+- **exact-head position** (target: hold ≤3), and
+- **family footprint** — how many queries in the term's family you rank for, and the
+  impressions they throw.
+
+Clicks are demoted to a **graduation tripwire**: when the term starts throwing real click
+volume, it has matured, and *that* is the trigger to shift weight toward conversion.
+
+### Why position is the wrong score for a mature page
+
+One property had a page at **position 6.6** — healthy by any rank metric — converting
+**0.53%**, and it was the site's largest impression generator by 2×. It sat untouched for a
+month because nothing scored it as a failure. A rising position on a page nobody clicks is not
+progress.
+
+Once mature, score on **clicks**, and keep position only as a diagnostic for trend continuity.
+Say so explicitly wherever you record it, or the number will start deciding work again.
+
+### The flip gate — make it computable, not a vibe
+
+"The families are all owned" cannot be read off GSC directly (GSC only shows queries you
+already appear for). So judge saturation with three numbers, and state all three every time
+you review:
+
+> Flip from land-grab to harvest when **`family_top3_share` ≥ 85%** AND **`family_queries` grew
+> <10% vs the prior read** AND **`family_weak` ≤ 2**.
+>
+> - `family_top3_share` — share of family *impressions* sitting at position ≤3
+> - `family_queries` — count of family queries you rank for
+> - `family_weak` — family queries at position >5 with ≥50 impressions (the improvement backlog)
+
+Until all three hold, stay in land-grab. Written down as numbers, the regime is never
+re-argued from scratch; written as prose, it softens into a vibe within three reviews.
+
+---
+
+## The four query families that never click
+
+Screen every low-CTR page against these **before** calling it a problem. This is what stops a
+clicks KPI from lying to you.
+
+1. **LLM fan-out.** An AI assistant decomposed a user's question into sub-searches. There is no
+   human in the loop, so these score zero clicks *by design, permanently*. Verified example: 41
+   queries shaped `"evaluate the software company {v0|framer|bolt} on ai ui generator"`, 812
+   impressions, **exactly 0 clicks** — at position 4.7–5.8. Ranking there means assistants are
+   pulling your page as a source. **It is a win that will look like failure to anyone grading
+   on clicks.** Track it on an AI-visibility scorecard instead, never on the clicks KPI.
+2. **Competitor-navigational.** "[competitor] by [parent company]" — the user wants the
+   competitor's own site. Unwinnable, no matter what you do to the page.
+3. **Brand-navigational.** Your own brand terms where the homepage should win. A blog page
+   "underperforming" on your brand name is correct behavior.
+4. **Anonymized tail.** GSC withholds long-tail queries for privacy. When a page's *visible*
+   impressions are <10% of its total, its tail is undiagnosable — one page showed 27 visible
+   impressions were well under 1% of the real total. You cannot diagnose what you cannot see.
+
+**Never delete, retitle, or count these against a page.** Write your own verified list down, or
+every review will rediscover and re-triage the same non-problems.
+
+---
+
+## GSC gotchas that produce false conclusions
+
+| Trap | What actually happens | What to do |
+|---|---|---|
+| **Data lag** | GSC is 2–3 days behind | End every window 3 days back |
+| **Position is impression-weighted** | A great position on 12 impressions is real but meaningless | Ignore rows under ~50 impressions |
+| **Query clicks < page clicks** | Anonymized queries are missing from the query dimension | Trust the **page** dimension for totals |
+| **apex vs www counted separately** | Both hosts get indexed; each shows partial numbers | Fold them together before reporting |
+| **Metric mis-binding** | Reporting page-dim total where exact-query was meant | Bind each metric to a named number in writing. One real dashboard spiked 10× from this. |
+| **Cached reports** | A saved report is a snapshot, not the truth | Always re-query the live system |
+
+---
+
+## Naming your KPI honestly
+
+Pick **one** KPI. Label everything else a diagnostic, in writing, or it will start deciding
+work.
+
+Then name the KPI's **successor** and park it honestly. On one property the chain is
+clicks → signups, and signups are *not* instrumented because Google referrers are
+path-stripped, so a signup cannot be attributed to a blog page from referrer data alone. That
+is written into the spec along with the instruction: **do not fake it from what GSC can
+reach.** An honestly-parked metric beats a fabricated one, and it tells the next person what
+to build.
+
+---
+
+## Attribution hygiene
+
+You can only learn from a change you can attribute.
+
+- **One edit per page per window.** Two changes inside 14 days and neither result is readable.
+- **Cooldowns:** breadwinner 14 days, other live pages 7 days.
+- **An unmerged PR is not live.** It cannot rank or pass link equity. While anything is
+  unmerged, a flat position is **expected**, not evidence of failure — and definitely not
+  grounds for a strategy change. Count and surface unmerged work every cycle.
+- **Stamp every change** with its applied date and a verify-after date, and actually check it.

--- a/skills/seo-growth/references/measurement.md
+++ b/skills/seo-growth/references/measurement.md
@@ -61,18 +61,18 @@ Screen every low-CTR page against these **before** calling it a problem. This is
 clicks KPI from lying to you.
 
 1. **LLM fan-out.** An AI assistant decomposed a user's question into sub-searches. There is no
-   human in the loop, so these score zero clicks *by design, permanently*. Verified example: 41
-   queries shaped `"evaluate the software company {v0|framer|bolt} on ai ui generator"`, 812
-   impressions, **exactly 0 clicks** — at position 4.7–5.8. Ranking there means assistants are
-   pulling your page as a source. **It is a win that will look like failure to anyone grading
-   on clicks.** Track it on an AI-visibility scorecard instead, never on the clicks KPI.
+   human in the loop, so these score zero clicks *by design, permanently*. A verified templated
+   competitor-evaluation query family recorded **0% CTR** at position 4.7–5.8. Ranking there
+   means assistants are pulling your page as a source. **It is a win that will look like failure
+   to anyone grading on clicks.** Track it on an AI-visibility scorecard instead, never on the
+   clicks KPI.
 2. **Competitor-navigational.** "[competitor] by [parent company]" — the user wants the
    competitor's own site. Unwinnable, no matter what you do to the page.
 3. **Brand-navigational.** Your own brand terms where the homepage should win. A blog page
    "underperforming" on your brand name is correct behavior.
 4. **Anonymized tail.** GSC withholds long-tail queries for privacy. When a page's *visible*
-   impressions are <10% of its total, its tail is undiagnosable — one page showed 27 visible
-   impressions were well under 1% of the real total. You cannot diagnose what you cannot see.
+   impressions are <10% of its total, its tail is undiagnosable — one page's visible impressions
+   were well under 1% of its real total. You cannot diagnose what you cannot see.
 
 **Never delete, retitle, or count these against a page.** Write your own verified list down, or
 every review will rediscover and re-triage the same non-problems.

--- a/skills/seo-growth/references/operationalize.md
+++ b/skills/seo-growth/references/operationalize.md
@@ -1,0 +1,81 @@
+# Operationalize — making it run without you
+
+Both playbooks are cycles, and a cycle a human runs by hand gets skipped the first busy week.
+This is how to hand it to scheduled agent loops.
+
+**Prerequisite: do not automate a stage you have never run by hand.** Automating an
+undiagnosed site produces confident output pointed at the wrong work, faster. Run at least a
+few cycles manually, learn your own carve-outs and archetypes, *then* encode them.
+
+---
+
+## Four roles, never one loop
+
+The biggest structural lesson from running these: **one "SEO loop" always collapses.**
+Measuring, shipping, improving, and answer-engine tracking run on different clocks and score
+on different metrics. Split them.
+
+| Role | Cadence | Scores on | Ships | Playbook |
+|---|---|---|---|---|
+| **Scout** | weekly | candidates found | one article, or a draft for approval | cold-start, and new fronts |
+| **Engine** | daily | position + family footprint | cluster articles (as PRs) | land-grab |
+| **Enrichment** | daily or every 3 days | clicks | one page edit (as a PR) | with-data |
+| **Scorecard** | weekly | nothing — it reports | a dated report | both |
+
+**The scorecard never ships anything.** Mixing measurement with action means one bad week
+rewrites the strategy.
+
+## Coordination rules
+
+Each of these exists because it failed first.
+
+1. **Hard carve-outs, written down.** Every page belongs to exactly one loop. Two loops editing
+   one page destroys attribution — you can no longer tell which change did what. Include your
+   crown-jewel page explicitly in whichever loop owns it.
+2. **Standing check before any edit:** has a sibling loop touched this page in the last 7 days?
+   If yes, skip it.
+3. **Stagger the schedules.** Same-minute fires collide on API quota and on the repo working
+   tree.
+4. **Human merges.** Loops open PRs; a person merges. Earn autonomy per-lane later, and only
+   for small additive changes on non-critical pages, capped at one per run, gated on a passing
+   build.
+
+## What each loop must do every run, regardless of role
+
+1. **Reconcile against the live system** before trusting any internal state.
+2. **Read the score** from pre-staged data — do not re-fetch what a deterministic pre-stage
+   already pulled. Re-fetching is the single largest cost sink these loops have.
+3. **Check the canary and respect cooldowns.**
+4. **Screen candidates for human intent** before treating anything as a problem.
+5. **Run the gates:** cannibalization, CTA test, primary-source fact-check, queue depth.
+6. **Ship at most one unit**, stamped with a verify-after date.
+7. **Report, and update its own durable state file.**
+
+## The durable state file is where the compounding lives
+
+Not the automation. Each loop keeps a brief with three sections:
+
+- **Spec** — what it does and when it speaks.
+- **Current understanding** — baselines, verified non-problems it must stop re-triaging,
+  candidates already ruled out and why, the ledger of applied changes, environment gotchas.
+- **Timeline** — one dated entry per run, distilled periodically to a milestone spine.
+
+**A loop that re-derives its conclusions every run is just an expensive cron job.** Most of the
+value is in "Current understanding" — specifically the list of things it must *stop*
+rediscovering.
+
+## Two runtime traps
+
+- **A scheduled run dies the instant the agent yields the turn.** Backgrounded work and
+  "notify me when done" waits die with it — there is no later. Long steps must be blocking
+  foreground calls. This killed real runs on two properties before it was understood.
+- **A long run can still lose its lease** if the machine sleeps. Keep runs short and chunk
+  anything lengthy.
+
+## A ready-made starting point
+
+`assets/seo-loop-template.md` in this skill is a fill-in-the-blanks loop spec that encodes the
+rules above as an actual run pipeline. Copy it, replace every `<FILL: …>` placeholder, and
+point your scheduler at it.
+
+To build the surrounding loop scaffolding, see the **`new-loop`** skill in this same plugin.

--- a/skills/seo-growth/references/why-these-rules.md
+++ b/skills/seo-growth/references/why-these-rules.md
@@ -1,8 +1,7 @@
 # Why these rules exist
 
 Every rule in this skill came from a production failure or a production result on two content
-properties run by AI Builder Club — one developer-education site, one design-tool site — under
-continuous, instrumented operation.
+properties under continuous, instrumented operation.
 
 **On the numbers below:** absolute traffic figures are withheld. Ratios, CTRs, positions, and
 thresholds are stated as actually observed, because those are the parts that transfer. A rule
@@ -44,7 +43,7 @@ repeatable losers. The shapes mattered far more than the topics.
 
 | Archetype | What the data showed |
 |---|---|
-| **Person-attached emerging convention** | The site's best page by a wide margin, at **~2.3% CTR**, with five more pages from the same cluster in the site's top 30. A technique named after a known person, caught early, compounds for months. |
+| **Person-attached emerging convention** | The site's best page by a wide margin, at **~2.3% CTR**. A technique named after a known person, caught early, compounds for months. |
 | **"[Tool] for [profession]" guides** | Highest-CTR template on the site: **3.0%**, **4.1%**, **4.8%** across different professions. Builder-mid-workflow intent with a native next step. Repeatable, because new professions keep appearing. |
 | **Named-technique guide + lead magnet** | A technique guide ranked well, and the query for its *PDF* converted at **12.3% CTR** — readers explicitly asking for a downloadable next step. |
 
@@ -62,7 +61,7 @@ empirically before anyone reasoned it out.
 
 ## Concentration is health, not risk
 
-On the design-tool property a single page earned roughly **45% of all blog clicks**, with the
+On Property B a single page earned roughly **45% of all blog clicks**, with the
 next page at about a third of that. The instinct to diversify away from that dependence was
 wrong, and acting on it would have been expensive.
 
@@ -97,8 +96,8 @@ title never contained that word.
 
 ## LLM fan-out scores zero clicks by design
 
-A family of **41 queries** shaped `"evaluate the software company {competitor} on {category}"`
-ran site-wide at **exactly 0 clicks** — while ranking at **position 4.7–5.8**.
+A templated competitor-evaluation query family ran site-wide at **0% CTR** while ranking at
+**position 4.7–5.8**.
 
 These are AI assistants decomposing a user's question into sub-searches. There is no human in
 the loop to click. Ranking there means assistants are pulling the pages as sources: a genuine

--- a/skills/seo-growth/references/why-these-rules.md
+++ b/skills/seo-growth/references/why-these-rules.md
@@ -1,0 +1,150 @@
+# Why these rules exist
+
+Every rule in this skill came from a production failure or a production result on two content
+properties run by AI Builder Club — one developer-education site, one design-tool site — under
+continuous, instrumented operation.
+
+**On the numbers below:** absolute traffic figures are withheld. Ratios, CTRs, positions, and
+thresholds are stated as actually observed, because those are the parts that transfer. A rule
+without its origin is just an opinion, so each one names the specific thing that went wrong or
+right.
+
+---
+
+## Emerging-term targeting works, and it works twice
+
+Two separate emerging terms were landed on the same property using the same method, months
+apart. The second is the cleaner demonstration: the pillar page went live and became **the
+site's most-clicked page within 7 days**, holding **position 1.5 at ~39% CTR** on the exact
+head term.
+
+None of that is achievable on an established term from a mid-authority domain. It is achievable
+on a three-week-old term because authority has not yet decided the SERP.
+
+**The first term's curve is the other half of the lesson:** it went from *zero* impressions to
+substantial weekly volume in about four weeks, while the site's rank sat at **~position 7 the
+entire time**. Graded on clicks, that reads as failure. Graded on position and footprint, it
+reads as what it was — a term maturing underneath a page already in place to catch it.
+
+**Value is front-loaded.** Once a competitor with real authority began framing the same term,
+position and CTR started normalizing down even as total impressions climbed. The window is real
+and it closes.
+
+**Day-7 read on the second term**, worth internalizing: position went **1.5 → 2.75** while
+clicks and the query family both roughly doubled. The position metric got *worse* while the
+term got substantially more valuable. That is why the regime flip in `measurement.md` is three
+numbers, not one.
+
+## Winning archetypes are extracted, not chosen
+
+A 90-day Search Console read on one property produced three repeatable winning shapes and three
+repeatable losers. The shapes mattered far more than the topics.
+
+**Winners:**
+
+| Archetype | What the data showed |
+|---|---|
+| **Person-attached emerging convention** | The site's best page by a wide margin, at **~2.3% CTR**, with five more pages from the same cluster in the site's top 30. A technique named after a known person, caught early, compounds for months. |
+| **"[Tool] for [profession]" guides** | Highest-CTR template on the site: **3.0%**, **4.1%**, **4.8%** across different professions. Builder-mid-workflow intent with a native next step. Repeatable, because new professions keep appearing. |
+| **Named-technique guide + lead magnet** | A technique guide ranked well, and the query for its *PDF* converted at **12.3% CTR** — readers explicitly asking for a downloadable next step. |
+
+**Losers — high impressions, no business:**
+
+| Shape | CTR |
+|---|---|
+| News / "Google kills X" | 0.4% |
+| New-product launch guide | 0.2% |
+| "Best [category] 2026" roundup | **0.04%** |
+
+All three pulled enormous impression volume. That is the trap: impressions feel like traction.
+All three fail the CTA test — a news reader has no next step — and Search Console confirmed it
+empirically before anyone reasoned it out.
+
+## Concentration is health, not risk
+
+On the design-tool property a single page earned roughly **45% of all blog clicks**, with the
+next page at about a third of that. The instinct to diversify away from that dependence was
+wrong, and acting on it would have been expensive.
+
+Compounding the winner instead produced **eight consecutive period-over-period rises** in blog
+clicks. Over the same stretch non-brand clicks grew steadily while brand clicks stayed flat —
+the mix shifted from overwhelmingly brand toward genuinely earned traffic. Non-brand is the
+growth signal; total traffic can look healthy while hiding that nothing new is being won.
+
+**The winner turned out to be position-limited, not snippet-limited** — CTR already **~9.5%** at
+roughly position 5.6. No amount of title editing would have helped. The lever was inbound
+internal links and depth, which is why that distinction gets its own section in `with-data.md`.
+
+## Position is the wrong score for a mature page
+
+One page sat at **position 6.6** converting **0.53%**, and it was the property's largest
+impression generator by 2×. It went untouched for a month because no metric in use scored it as
+a failure. A rising position on a page nobody clicks is not progress.
+
+After its title and description were re-pointed at the specific angle only that property could
+credibly own, CTR moved **0.53% → 0.83%** on ~19% more impressions.
+
+**That was recorded as a hypothesis, not a fix** — the measurement window straddled the change
+and ~89% of the page's impressions were anonymized by Search Console, so the honest verdict was
+deferred to a clean scheduled recheck. That discipline is as much the lesson as the result.
+
+## The CTR bottleneck is usually a naming problem
+
+Across one property's top pages, a very large impression base converted at well under 1%. The
+constraint was not ranking. It was that **titles did not contain the queries the pages ranked
+for.** Canonical case: a page ranking around **position 8.5** for a one-word compound term whose
+title never contained that word.
+
+## LLM fan-out scores zero clicks by design
+
+A family of **41 queries** shaped `"evaluate the software company {competitor} on {category}"`
+ran site-wide at **exactly 0 clicks** — while ranking at **position 4.7–5.8**.
+
+These are AI assistants decomposing a user's question into sub-searches. There is no human in
+the loop to click. Ranking there means assistants are pulling the pages as sources: a genuine
+win that looks like total failure to anyone grading on clicks, and that a well-meaning
+optimization pass will try to "fix."
+
+Related and equally important: pages whose *visible* impressions are a tiny fraction of the
+total are undiagnosable. One page's visible impressions were **well under 1%** of its actual
+total; others ran 89–93% anonymized. You cannot diagnose what the tool will not show you.
+
+## The closed-loop failure
+
+An automated SEO process ran for nine days doing internal improvements only — reshuffling links,
+tightening pages — grounding entirely on its own pages and its own Search Console data. Its head
+term **slipped to page 2.**
+
+The industry-wide term shift it needed to react to had been sitting in the owner's own saved
+bookmarks the whole time, unread: two widely-shared posts had already announced the migration
+from the old term to a new one. The process had access to the answer and never looked outside
+itself.
+
+**Grounding on your own data is a closed loop.** It produces internal reshuffles that cannot move
+a term you do not yet own. The fix — curated stream first, always — is why `emerging-terms.md`
+specifies a sourcing *order* rather than a list of sources. The follow-on term, hunted properly,
+landed at #1 site clicks within a week.
+
+## The state-drift failure
+
+Five articles shipped live and nobody updated their status in the tracking system. Three
+consecutive automated runs reported *"nothing shipped"* and counted five phantom drafts — for two
+days **after** the articles were in production. Worse, a cannibalization audit ran against that
+stale mirror, so its fixes were computed against pages that no longer matched reality and changed
+nothing.
+
+**Fix:** reconcile against the live system before trusting internal state, every run, keyed on
+**URL rather than title** — titles routinely get rewritten at publish time, so title-matching
+fails silently exactly when it matters.
+
+## The fabrication failure
+
+A content-enrichment pass "grounded" a new FAQ in the target page's own existing body and shipped
+**four wrong technical facts** — CLI flags that did not exist. The page's body was stale, so
+grounding in it laundered the error into a freshly query-targeted answer, which is precisely
+where a wrong specific does the most damage: it misleads the exact searcher you are trying to
+win.
+
+**Fix:** any *new* verifiable specific — a flag, env var, parameter, default, version behavior,
+price — must be checked against a primary source in the same run, with the doc URL recorded.
+Grounding in your own existing content is not verification.

--- a/skills/seo-growth/references/with-data.md
+++ b/skills/seo-growth/references/with-data.md
@@ -52,7 +52,7 @@ Worked example — the archetypes one property extracted from a 90-day Search Co
 
 | Archetype | Evidence |
 |---|---|
-| **Person-attached emerging convention** | The site's best page by a wide margin at ~2.3% CTR, plus five more from the same cluster in its top 30. A technique named after a known person, caught early, compounds for months. |
+| **Person-attached emerging convention** | The site's best page by a wide margin at ~2.3% CTR. A technique named after a known person, caught early, compounds for months. |
 | **"[Tool] for [profession]" guides** | Highest-CTR template on the site: 3.0%, 4.1%, 4.8% across different professions. Builder-mid-workflow intent, natural funnel. Repeatable — new professions keep appearing. |
 | **Named-technique guides you can own** | A technique guide ranked well, and the query for its **PDF** converted at 12.3% CTR — readers explicitly asking for a downloadable next step. When a technique guide ships, add a checklist/PDF CTA. |
 
@@ -83,9 +83,9 @@ Pull the page's **query mix**, then classify:
 The single most common misdiagnosis. Four query families score ~zero clicks **by design**:
 
 - **LLM fan-out** — an assistant decomposed a question into sub-searches. No human, no click,
-  ever. One verified family: 41 queries shaped `"evaluate the software company {competitor} on
-  {category}"`, **exactly 0 clicks** — while ranking position 4.7–5.8, which means AI assistants
-  are finding and citing the pages. That is a win that scores zero forever.
+  ever. One verified templated competitor-evaluation query family recorded **0% CTR** while
+  ranking position 4.7–5.8, which means AI assistants are finding and citing the pages. That is
+  a win that scores zero forever.
 - **Competitor-navigational** — "[competitor] by [parent company]" means they want the
   competitor's own site. Unwinnable.
 - **Brand-navigational** — your homepage should win it, not this page.

--- a/skills/seo-growth/references/with-data.md
+++ b/skills/seo-growth/references/with-data.md
@@ -1,0 +1,180 @@
+# Playbook B — Existing site, with data
+
+**You are here if:** GSC has real rows. Something ranks, something earns clicks, and the
+question is where to point effort next.
+
+**The one thing to understand:** with data, **what to double down on is derived, not chosen.**
+Your own Search Console already knows which page shapes work for your audience and which
+don't. Most sites never read it that way and instead pick topics from intuition, competitor
+blogs, or keyword-tool volume — all of which are guesses about a question you can answer
+exactly.
+
+The sequence below is: read → find the winner → extract the shape → diagnose → compound →
+protect → verify.
+
+---
+
+## 1. Read your data properly
+
+Pull a 28-day window ending **3 days back** (GSC lags 2–3 days). You need three views:
+
+- **Page dimension** — clicks, impressions, CTR, position per page. This ranks your work.
+- **Query dimension** — the same, per query.
+- **Query mix for a specific page** — queries filtered to one page. This is the view that
+  prevents the most common expensive mistake (see §4).
+
+Read `measurement.md` before trusting any of it. GSC has specific traps — impression-weighted
+position, anonymized long tails, apex vs www counted separately — that produce confident wrong
+conclusions.
+
+## 2. Find your breadwinner
+
+**The breadwinner is the single page earning ≥30% of your clicks.** Most sites that work have
+one. On one property it was ~45% of all blog clicks, with the next page at about a third of that.
+
+**Concentration is not a problem to fix.** The instinct to "diversify away from dependence on
+one page" is wrong at this stage and expensive: it moves effort off the one asset that is
+demonstrably working, onto pages that have not earned it. **Compound the winner first.**
+Breadth gets attention only once the winner is fully compounded.
+
+## 3. Extract your winning archetypes — this is the real answer to "what do we double down on"
+
+Do not double down on a *page*. Double down on the **shape** that page belongs to, then repeat
+the shape.
+
+Sort your pages by clicks and CTR and ask what the top ones have structurally in common — who
+the searcher is, what they were doing, what form the page takes. Then do the same for the
+bottom. You are looking for repeatable *templates*, not topics.
+
+Worked example — the archetypes one property extracted from a 90-day Search Console read:
+
+**Winners:**
+
+| Archetype | Evidence |
+|---|---|
+| **Person-attached emerging convention** | The site's best page by a wide margin at ~2.3% CTR, plus five more from the same cluster in its top 30. A technique named after a known person, caught early, compounds for months. |
+| **"[Tool] for [profession]" guides** | Highest-CTR template on the site: 3.0%, 4.1%, 4.8% across different professions. Builder-mid-workflow intent, natural funnel. Repeatable — new professions keep appearing. |
+| **Named-technique guides you can own** | A technique guide ranked well, and the query for its **PDF** converted at 12.3% CTR — readers explicitly asking for a downloadable next step. When a technique guide ships, add a checklist/PDF CTA. |
+
+**Losers — do not pick these even when they look emerging and rankable:**
+
+| Shape | CTR |
+|---|---|
+| News / announcement ("Google kills X") | 0.4% |
+| Launch guide for a new product | 0.2% |
+| "Best [category] 2026" roundup | **0.04%** |
+
+That last table is GSC empirically confirming the CTA test: massive impressions, near-zero
+clicks, no funnel value. A news reader has no next step.
+
+**Your archetypes will differ.** The transferable part is the method — read your own top and
+bottom pages for structural commonality, write the list down, and check every future candidate
+against it.
+
+## 4. Diagnose before you touch anything
+
+A page with impressions and few clicks is one of **three** different problems with three
+different treatments. Getting this wrong wastes the effort and can lose you the page.
+
+Pull the page's **query mix**, then classify:
+
+### (a) Not broken — leave it alone
+
+The single most common misdiagnosis. Four query families score ~zero clicks **by design**:
+
+- **LLM fan-out** — an assistant decomposed a question into sub-searches. No human, no click,
+  ever. One verified family: 41 queries shaped `"evaluate the software company {competitor} on
+  {category}"`, **exactly 0 clicks** — while ranking position 4.7–5.8, which means AI assistants
+  are finding and citing the pages. That is a win that scores zero forever.
+- **Competitor-navigational** — "[competitor] by [parent company]" means they want the
+  competitor's own site. Unwinnable.
+- **Brand-navigational** — your homepage should win it, not this page.
+- **Anonymized tail** — GSC hides long-tail queries. A page whose *visible* impressions are
+  <10% of its total is undiagnosable; one page's visible impressions were well under 1% of the real total.
+
+**Never "fix", retitle, or delete these, and never count them against a page.** Screening
+first is what stops a clicks-based KPI from lying to you.
+
+### (b) Snippet-limited — the page ranks, the listing doesn't sell
+
+Query mix is **human**, position is decent (≤15), CTR is poor, and the title/H1/meta **fail to
+name the exact query the page ranks for.**
+
+The canonical case: a page ranking ~position 8.5 for a one-word compound term whose title never
+contained that word.
+
+**Treatment, roughly by leverage:** query-match the title / H1 / meta description to the exact
+human query · add a fresh PAA-style FAQ in question-form heading with a tight extractable
+answer · tighten the actual answer into the first 30% of the page · add honest structured data.
+
+### (c) Position-limited — the listing is fine, the rank isn't
+
+CTR is already healthy (say >8%) but position sits at 5–7. Editing the page does almost
+nothing here; the constraint is authority, not copy.
+
+**Treatment:**
+- **Internal link equity.** One contextual, intent-matched link per cycle from a
+  high-impression page of yours *into* the target, with descriptive anchor text. This is the
+  highest-leverage move available when a winner is position-limited, and it isn't on the page
+  at all. Run it as a campaign: work down your high-impression pages one at a time, then log
+  it **exhausted** when no untouched source page remains.
+- **Depth a thin competitor cannot match.** Interactive or tool-like assets, honest comparison
+  tables, first-party specifics, real diagrams. This is what you spend the winner's cooldown
+  windows building.
+
+## 5. Protect the winner — canary and cooldowns
+
+**A winning page is production.** Treat edits to it the way you would treat a deploy.
+
+- **Canary, every cycle:** if the breadwinner's position drops ≥3, or its clicks drop >30%
+  window-over-window, **stop and investigate before doing anything else**, and make no edits to
+  it that cycle.
+- **Cooldowns:** breadwinner **14 days**, every other live page **7 days** between edits. One
+  edit per page per window — otherwise you cannot attribute the result to the change, and you
+  lose the ability to learn anything.
+- A page inside its cooldown is off-limits even for a "small" tweak. Route the idea elsewhere
+  or hold it.
+- **It is correct to leave clicks on the table rather than perturb the page that earns half of
+  them.**
+
+## 6. Verify — a ship is not an outcome
+
+Every change gets a scheduled verdict, or you are just doing activity.
+
+Stamp each applied change with the date and a **verify-after date 14 days out**. When it comes
+due, compare that page's clicks **7 days after** vs **7 days before** the change. If a page
+with real *human* traffic dropped **>30%**, that is a **revert candidate** — name the change,
+the page, the numbers, and the exact commit. Otherwise mark it verified and move on.
+
+An applied change that was never verified is an open loop, not a done item.
+
+For a newly shipped article, two extra checks at ~4 weeks: did its target query family
+actually form (near-zero → refresh or merge it into the pillar), and did it *hurt* the pillar
+(pillar position degraded >2 while the new page absorbs the pillar's old queries → consolidate).
+
+## 7. Keep a front open
+
+A mature cluster still saturates. Once you own every intent worth owning in a territory,
+further effort there returns little — that is when a site plateaus despite consistent output.
+The answer is not more pages in the saturated cluster; it is **a new front**.
+
+Go back to `emerging-terms.md` and hunt. A site with authority hunting an emerging term is the
+strongest position in this entire method: you get the thin-competition window *and* the domain
+strength. That is how one property's second emerging term landed at #1 site clicks within 7 days
+of launch, while its first term was still being defended.
+
+---
+
+## The cycle, compressed
+
+1. Reconcile what is actually live against what you think is live (state drifts; verify against
+   the live site, not your notes).
+2. Read the score. One KPI, everything else labeled a diagnostic.
+3. Check the canary; respect cooldowns.
+4. Pick the single highest click-opportunity move; screen it for human intent first.
+5. Run the gates: cannibalization, CTA, fact-check any new technical specific against a primary
+   source, queue depth.
+6. Ship one thing. Stamp it with a verify date.
+7. When the cluster saturates, open a new front.
+
+To make this run without you, see `operationalize.md`.


### PR DESCRIPTION
Distills the SEO method we run on two content properties into a skill anyone can use.

## Why this split

The skill routes on the one question that actually determines the right move: **do you have Search Console data yet or not?** A site with no rankings and a site with a breadwinner page need opposite behavior, and most stalled SEO effort is stage-mismatched advice rather than wrong advice.

- **Playbook A — cold start.** You cannot win an established head term from zero authority. So a cold start doesn't do SEO in the normal sense, it hunts emerging terms: instrument first, answer the CTA test, ship ONE page rather than a cluster, measure at day 7 and decide at day 21.
- **Playbook B — with data.** What to double down on is *derived, not chosen*. Find the page earning ≥30% of clicks, extract the archetype it belongs to, then diagnose: a low-CTR page is one of three different problems (not broken / snippet-limited / position-limited) with three different treatments.

## Contents

| File | What it holds |
|---|---|
| `SKILL.md` | Router, the three numbers to pull before advising anything, five laws |
| `references/cold-start.md` | Playbook A, six steps, and what not to do |
| `references/with-data.md` | Playbook B, archetype extraction, the three-way diagnosis, canary + cooldowns |
| `references/emerging-terms.md` | The hunt: sourcing order, seven validation gates, validating demand when tools show zero volume |
| `references/measurement.md` | Which metric scores which regime, the four query families that never click, Search Console traps |
| `references/why-these-rules.md` | The failure or result behind each rule |
| `references/operationalize.md` | Four loop roles, coordination rules |
| `assets/seo-loop-template.md` | Fill-in-the-blanks loop spec |

## On the data

Our own absolute traffic figures are **withheld**. Ratios, CTRs, positions and thresholds are stated as actually observed, because those are the parts that transfer. Properties are described by type, not named.

## Scope

Derived from B2B / developer-tool / creator-education content SEO on low-to-mid authority domains. The playbook split, the measurement discipline and the emerging-term method transfer broadly; the specific archetypes do not, and the skill says so. Local, e-commerce and YMYL were never tested here.

Also updates the README skill list and adds SEO keywords to `plugin.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsYTgMZtXDGHYg4arAX366